### PR TITLE
[api] fix dev watch

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
     "supertest": "^7.1.3",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
+    "tsc-watch": "^7.1.1",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## Contexte et objectif
L'exécution `pnpm dev` échouait car NestJS ne trouvait pas `dist/main.js`. Le package `tsc-watch` manquait pour compiler automatiquement en mode watch.

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/api dev`

## Impact sur les autres modules
Aucun.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687edc6f5f7c832198f545a60076833c