### PR TITLE
[api] inject LogParser via providers

### DIFF
--- a/apps/api/src/log-analysis/log-analysis.service.ts
+++ b/apps/api/src/log-analysis/log-analysis.service.ts
@@ -7,7 +7,7 @@ import { AnalyzeLogDto } from "./dto/analyze-log.dto";
 export class LogAnalysisService {
   private readonly logger = new Logger(LogAnalysisService.name);
 
-  constructor(private readonly parser: LogParser = new LogParser()) {}
+  constructor(private readonly parser: LogParser) {}
 
   async analyze(dto: AnalyzeLogDto): Promise<ParsedLog> {
     if (!dto.filePath) {


### PR DESCRIPTION
## Contexte et objectif
- utilise l'injection Nest pour `LogParser`
- retire l'instanciation directe dans `LogAnalysisService`

## Étapes pour tester
1. `pnpm -F @testlog-inspector/log-parser build`
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
- aucun impact attendu hors du service d'analyse

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687f7b06d9908321983bfad2fdd403e5