### PR TITLE
[api] size limit config

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -9,7 +9,7 @@ Each variable has a sensible default so the stack runs out‑of‑the‑box.
 | `PORT` | `3001` | Port on which the NestJS API listens. |
 | `CORS_ORIGIN` | `http://localhost:3000` | Allowed origin for CORS requests to the API. |
 | `NODE_ENV` | `development` | Node runtime environment. |
-| `MAX_UPLOAD_SIZE` | `52428800` | Maximum upload size in bytes (default 50MB). |
+| `MAX_UPLOAD_SIZE` | `52428800` | Maximum size in bytes for uploads and JSON bodies (50MB default). |
 | `CI` | *unset* | When defined, Playwright will not reuse an existing dev server. |
 
 These variables can be provided via `.env` files or your host environment.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Les principales variables de configuration sont décrites dans
 `http://localhost:3001` et le frontend pointe vers cette URL via
 `NEXT_PUBLIC_API_URL`.
 
+`MAX_UPLOAD_SIZE` permet d'ajuster la taille maximale autorisée pour les requêtes
+et les fichiers envoyés (50 Mo par défaut).
+
 ---
 
 ## 🛠️ Pile technologique

--- a/apps/api/src/common/constants.ts
+++ b/apps/api/src/common/constants.ts
@@ -5,7 +5,5 @@ export const MAX_UPLOAD_SIZE = process.env.MAX_UPLOAD_SIZE
   ? Number(process.env.MAX_UPLOAD_SIZE)
   : 50 * 1024 * 1024;
 
-// Express expects values like '50mb'
-export const MAX_UPLOAD_SIZE_LABEL = `${Math.ceil(
-  MAX_UPLOAD_SIZE / (1024 * 1024),
-)}mb`;
+// Express body-parser expects bytes when using a numeric limit
+

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,7 +4,7 @@ import { json, urlencoded } from 'express';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
-import { MAX_UPLOAD_SIZE_LABEL } from './common/constants';
+import { MAX_UPLOAD_SIZE } from './common/constants';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -16,8 +16,8 @@ async function bootstrap() {
   app.use(helmet());
 
   // Keep body size consistent with upload limit
-  app.use(json({ limit: MAX_UPLOAD_SIZE_LABEL }));
-  app.use(urlencoded({ extended: true, limit: MAX_UPLOAD_SIZE_LABEL }));
+  app.use(json({ limit: MAX_UPLOAD_SIZE }));
+  app.use(urlencoded({ extended: true, limit: MAX_UPLOAD_SIZE }));
 
   /* ---------- Global validation (class-validator) ---------- */
   app.useGlobalPipes(

--- a/env.d.ts
+++ b/env.d.ts
@@ -12,7 +12,7 @@ declare namespace NodeJS {
     /** Environnement d’exécution */
     readonly NODE_ENV: "development" | "production" | "test";
 
-    /** Max upload size in bytes (default 50MB) */
+    /** Max upload size in bytes for Multer and body parsing (default 50MB) */
     readonly MAX_UPLOAD_SIZE?: string;
   }
 }


### PR DESCRIPTION
## Contexte et objectif
- centralise la limite de taille en utilisant `MAX_UPLOAD_SIZE`
- ajuste `json` et `urlencoded`
- documente la variable d'environnement

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact sur les autres modules
- API : même limite appliquée aux fichiers et au body

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687f8b8d244883218df8d3d9c886982f