### PR TITLE
[parser] lecture unique

### DIFF
--- a/packages/log-parser/src/parser.ts
+++ b/packages/log-parser/src/parser.ts
@@ -19,16 +19,14 @@ export class LogParser {
   }
 
   /**
-   * Lit le fichier 5 fois (simulate heavy passes) et renvoie un ParsedLog.
+   * Lit le fichier une seule fois et renvoie un ParsedLog.
    * @throws Error si le fichier est inaccessible ou corrompu.
    */
   async parseFile(path: string): Promise<ParsedLog> {
     if (!path) throw new Error("No file path provided");
     let content = "";
     try {
-      for (let i = 0; i < 5; i++) {
-        content = await fs.readFile(path, "utf-8");
-      }
+      content = await fs.readFile(path, "utf-8");
     } catch (e) {
       throw new Error(`Unable to read file "${path}" — ${(e as Error).message}`);
     }

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,7 +1,9 @@
 import { LogParser } from "@testlog-inspector/log-parser";
 import { writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { vi } from "vitest";
 
 describe("LogParser", () => {
   const tmp = join(tmpdir(), "test.log");
@@ -13,7 +15,7 @@ describe("LogParser", () => {
     } catch (_) {}
   });
 
-  it("should parse a nominal log file", async () => {
+  it("should parse a nominal log file using a single read", async () => {
     const content = `
       Scenario: login_flow
       Date: 2025-07-20
@@ -26,7 +28,9 @@ describe("LogParser", () => {
     writeFileSync(tmp, content);
 
     const parser = new LogParser();
+    const spy = vi.spyOn({ readFile }, "readFile");
     const res = await parser.parseFile(tmp);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     expect(res.context.scenario).toBe("login_flow");
     expect(res.errors).toHaveLength(1);


### PR DESCRIPTION
## Contexte et objectif
- simplifier la lecture de fichier dans `LogParser` en la faisant une seule fois
- mettre à jour le test associé pour vérifier qu'un seul `readFile` est effectué

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
- aucun impact attendu, l'API continue d'utiliser `LogParser`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687f9009549083218ea8db51d814c579