### PR TITLE
[docs] Document upload limit variable

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -10,6 +10,7 @@ Each variable has a sensible default so the stack runs out‑of‑the‑box.
 | `CORS_ORIGIN` | `http://localhost:3000` | Allowed origin for CORS requests to the API. |
 | `NODE_ENV` | `development` | Node runtime environment. |
 | `MAX_UPLOAD_SIZE` | `52428800` | Maximum size in bytes for uploads and JSON bodies (50MB default). |
+| `UPLOAD_LIMIT_MB` | `50` | Alternate way to set the maximum upload size in megabytes. |
 | `CI` | *unset* | When defined, Playwright will not reuse an existing dev server. |
 
 These variables can be provided via `.env` files or your host environment.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Les principales variables de configuration sont décrites dans
 
 `MAX_UPLOAD_SIZE` permet d'ajuster la taille maximale autorisée pour les requêtes
 et les fichiers envoyés (50 Mo par défaut).
+Vous pouvez aussi définir `UPLOAD_LIMIT_MB` pour spécifier la limite directement
+en mégaoctets (`UPLOAD_LIMIT_MB=100` autorise 100 Mo).
 
 ---
 


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une nouvelle variable d'environnement `UPLOAD_LIMIT_MB` permettant de définir la taille maximale d'upload en mégaoctets.
La documentation a été mise à jour pour expliquer son usage.

## Étapes pour tester
1. Lire `ENVIRONMENT.md` et `README.md` pour vérifier l'ajout de `UPLOAD_LIMIT_MB`.
2. Lancer `pnpm lint` et `pnpm test`.

## Impact sur les autres modules
Aucun impact fonctionnel, uniquement de la documentation.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687f94497a6c8321a55fd94944f8727b