### PR TITLE
[api] injection via parser interface

### DIFF
--- a/apps/api/src/log-analysis/log-analysis.module.ts
+++ b/apps/api/src/log-analysis/log-analysis.module.ts
@@ -17,7 +17,11 @@ import { LogParser } from '@testlog-inspector/log-parser';
     MulterModule,
   ],
   controllers: [LogAnalysisController],
-  providers: [LogAnalysisService, LogParser, FileValidator],
+  providers: [
+    LogAnalysisService,
+    { provide: 'ILogParser', useClass: LogParser },
+    FileValidator,
+  ],
   exports: [LogAnalysisService, FileValidator],
 })
 export class LogAnalysisModule {}

--- a/apps/api/src/log-analysis/log-analysis.service.spec.ts
+++ b/apps/api/src/log-analysis/log-analysis.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 
 import { LogAnalysisService } from './log-analysis.service';
-import { LogParser, ParsedLog } from '@testlog-inspector/log-parser';
+import { ParsedLog, ILogParser } from '@testlog-inspector/log-parser';
 import type { Express } from 'express';
 import { FileValidator } from './file-validator.service';
 
@@ -32,13 +32,13 @@ describe('LogAnalysisService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LogAnalysisService,
-        { provide: LogParser, useClass: MockLogParser },
+        { provide: 'ILogParser', useClass: MockLogParser },
         { provide: FileValidator, useClass: MockValidator },
       ],
     }).compile();
 
     service = module.get<LogAnalysisService>(LogAnalysisService);
-    parser = module.get<LogParser>(LogParser) as unknown as MockLogParser;
+    parser = module.get<ILogParser>('ILogParser') as unknown as MockLogParser;
     validator = module.get<FileValidator>(FileValidator) as unknown as MockValidator;
   });
 

--- a/apps/api/src/log-analysis/log-analysis.service.ts
+++ b/apps/api/src/log-analysis/log-analysis.service.ts
@@ -1,7 +1,6 @@
-import { Injectable, Logger, BadRequestException } from "@nestjs/common";
+import { Injectable, Logger, BadRequestException, Inject } from "@nestjs/common";
 import type { Express } from "express";
-import { LogParser } from "@testlog-inspector/log-parser";
-import { ParsedLog } from "@testlog-inspector/log-parser";
+import { ParsedLog, ILogParser } from "@testlog-inspector/log-parser";
 import { FileValidator } from "./file-validator.service";
 
 @Injectable()
@@ -9,7 +8,7 @@ export class LogAnalysisService {
   private readonly logger = new Logger(LogAnalysisService.name);
 
   constructor(
-    private readonly parser: LogParser,
+    @Inject('ILogParser') private readonly parser: ILogParser,
     private readonly validator: FileValidator,
   ) {}
 

--- a/packages/log-parser/index.ts
+++ b/packages/log-parser/index.ts
@@ -14,6 +14,7 @@
 
 export * from "./src/parser.js";
 export * from "./src/types.js";
+export * from "./src/ILogParser.js";
 
 export { DefaultStrategy } from "./src/strategies/default-strategy.js";
 export { BaseStrategy } from "./src/strategies/base-strategy.js";

--- a/packages/log-parser/src/ILogParser.ts
+++ b/packages/log-parser/src/ILogParser.ts
@@ -1,0 +1,6 @@
+import type { ParsedLog } from './types';
+
+export interface ILogParser {
+  parseFile(path: string): Promise<ParsedLog>;
+}
+


### PR DESCRIPTION
## Contexte et objectif
- introduit l'interface `ILogParser` dans le package parser
- LogAnalysisService dépend maintenant de cette interface
- le module fournit `LogParser` comme implémentation
- mise à jour des tests unitaires

## Étapes pour tester
1. `pnpm install`
2. `pnpm build --filter @testlog-inspector/log-parser`
3. `pnpm lint`
4. `pnpm test`

## Impact sur les autres modules
- pas d'impact attendu hors de l'injection du service

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fb62cc7b48321af87ab23bbc5232d