### PR TITLE
[api] Extraction du service de validation

### DIFF
--- a/apps/api/src/log-analysis/file-validation.service.spec.ts
+++ b/apps/api/src/log-analysis/file-validation.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import type { Express } from 'express';
+import { FileValidationService } from './file-validation.service';
+import { FileValidator } from './file-validator.service';
+
+class MockFileValidator {
+  validate = jest.fn();
+}
+
+describe('FileValidationService', () => {
+  let service: FileValidationService;
+  let validator: MockFileValidator;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FileValidationService,
+        { provide: FileValidator, useClass: MockFileValidator },
+      ],
+    }).compile();
+
+    service = module.get<FileValidationService>(FileValidationService);
+    validator = module.get<FileValidator>(FileValidator) as unknown as MockFileValidator;
+  });
+
+  it('should delegate validation to FileValidator', () => {
+    const file = { path: '/tmp/foo.log', originalname: 'foo.log', size: 1 } as Express.Multer.File;
+
+    service.validate(file);
+
+    expect(validator.validate).toHaveBeenCalledWith(file);
+  });
+
+  it('should throw when file has no path', () => {
+    expect(() => service.validate({} as Express.Multer.File)).toThrow(BadRequestException);
+    expect(validator.validate).not.toHaveBeenCalled();
+  });
+
+  it('should propagate errors from FileValidator', () => {
+    const file = { path: '/tmp/foo.log', originalname: 'foo.log', size: 1 } as Express.Multer.File;
+    validator.validate.mockImplementation(() => {
+      throw new BadRequestException('nope');
+    });
+
+    expect(() => service.validate(file)).toThrow('nope');
+  });
+});

--- a/apps/api/src/log-analysis/file-validation.service.ts
+++ b/apps/api/src/log-analysis/file-validation.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import type { Express } from 'express';
+import { FileValidator } from './file-validator.service';
+
+/**
+ * Coordinates all checks on the uploaded file before parsing.
+ * Validates presence, then delegates extension/size checks to FileValidator.
+ */
+@Injectable()
+export class FileValidationService {
+  constructor(private readonly validator: FileValidator) {}
+
+  validate(file: Express.Multer.File): void {
+    if (!file?.path) {
+      throw new BadRequestException('file is required');
+    }
+    this.validator.validate(file);
+  }
+}

--- a/apps/api/src/log-analysis/log-analysis.module.ts
+++ b/apps/api/src/log-analysis/log-analysis.module.ts
@@ -4,6 +4,7 @@ import { MulterModule } from '@nestjs/platform-express';
 import { LogAnalysisController } from './log-analysis.controller';
 import { LogAnalysisService } from './log-analysis.service';
 import { FileValidator } from './file-validator.service';
+import { FileValidationService } from './file-validation.service';
 import { LogParser } from '@testlog-inspector/log-parser';
 
 /**
@@ -21,7 +22,8 @@ import { LogParser } from '@testlog-inspector/log-parser';
     LogAnalysisService,
     { provide: 'ILogParser', useClass: LogParser },
     FileValidator,
+    FileValidationService,
   ],
-  exports: [LogAnalysisService, FileValidator],
+  exports: [LogAnalysisService, FileValidator, FileValidationService],
 })
 export class LogAnalysisModule {}

--- a/apps/api/src/log-analysis/log-analysis.service.ts
+++ b/apps/api/src/log-analysis/log-analysis.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, BadRequestException, Inject } from "@nestjs/common";
 import type { Express } from "express";
 import { ParsedLog, ILogParser } from "@testlog-inspector/log-parser";
-import { FileValidator } from "./file-validator.service";
+import { FileValidationService } from "./file-validation.service";
 
 @Injectable()
 export class LogAnalysisService {
@@ -9,14 +9,10 @@ export class LogAnalysisService {
 
   constructor(
     @Inject('ILogParser') private readonly parser: ILogParser,
-    private readonly validator: FileValidator,
+    private readonly validator: FileValidationService,
   ) {}
 
   async analyze(file: Express.Multer.File): Promise<ParsedLog> {
-    if (!file?.path) {
-      throw new BadRequestException("file is required");
-    }
-
     this.validator.validate(file);
 
     try {


### PR DESCRIPTION
## Contexte et objectif
- Déplacement de la vérification des fichiers dans `FileValidationService` pour alléger `LogAnalysisService`.
- Injection du nouveau service dans `log-analysis.module.ts`.
- Ajustement des tests existants et ajout de ceux dédiés à `FileValidationService`.

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact sur les autres modules
- Aucun impact attendu en dehors du module d'analyse de logs.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fbbe111d48321b2d167600210c7a4