### PR TITLE
[log-parser] Ajout de tests de stratégie

### DIFF
--- a/packages/log-parser/json-strategy.spec.ts
+++ b/packages/log-parser/json-strategy.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+import { JsonStrategy } from '@parser/strategies/json-strategy';
+import type { IParsingStrategy, ParsedLog } from '@parser/types';
+
+// Ensure class implements the interface at runtime
+const strategy: IParsingStrategy = new JsonStrategy();
+
+test('JsonStrategy canHandle ND-JSON', () => {
+  const lines = [
+    '{"level":"INFO","message":"start","scenario":"login","date":"2025"}',
+    '{"level":"ERROR","message":"boom"}'
+  ];
+  expect(strategy.canHandle(lines)).toBe(true);
+});
+
+test('JsonStrategy parses ND-JSON', () => {
+  const lines = [
+    '{"level":"INFO","message":"start","scenario":"login","date":"2025"}',
+    '{"level":"ERROR","message":"boom"}'
+  ];
+
+  const parsed: ParsedLog = strategy.parse(lines);
+  expect(parsed).toHaveProperty('summary');
+  expect(parsed).toHaveProperty('context');
+  expect(parsed).toHaveProperty('errors');
+  expect(parsed.errors.length).toBe(1);
+});

--- a/packages/log-parser/junit-strategy.spec.ts
+++ b/packages/log-parser/junit-strategy.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest';
+import { JunitStrategy } from '@parser/strategies/junit-strategy';
+import type { IParsingStrategy, ParsedLog } from '@parser/types';
+
+const strategy: IParsingStrategy = new JunitStrategy();
+
+test('JunitStrategy canHandle XML reports', () => {
+  const lines = [
+    '<?xml version="1.0"?>',
+    '<testsuite name="suite" timestamp="2025">',
+    '</testsuite>'
+  ];
+  expect(strategy.canHandle(lines)).toBe(true);
+});
+
+test('JunitStrategy parses XML report', () => {
+  const lines = [
+    '<testsuite name="suite" timestamp="2025">',
+    '<testcase name="tc1"><failure type="Error" message="boom">stack</failure></testcase>',
+    '</testsuite>'
+  ];
+
+  const parsed: ParsedLog = strategy.parse(lines);
+  expect(parsed).toHaveProperty('summary');
+  expect(parsed).toHaveProperty('context');
+  expect(parsed).toHaveProperty('errors');
+  expect(parsed.errors.length).toBe(1);
+});

--- a/packages/log-parser/log-parser-selection.spec.ts
+++ b/packages/log-parser/log-parser-selection.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test, vi } from 'vitest';
+import { LogParser } from '@parser/parser';
+import { JsonStrategy } from '@parser/strategies/json-strategy';
+import { JunitStrategy } from '@parser/strategies/junit-strategy';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function tempFile(name: string, content: string): string {
+  const p = join(tmpdir(), name);
+  writeFileSync(p, content);
+  return p;
+}
+
+test('LogParser selects JsonStrategy', async () => {
+  const jsonPath = tempFile('log.json',
+    '{"level":"INFO","message":"start"}\n{"level":"ERROR","message":"fail"}');
+  const json = new JsonStrategy();
+  const junit = new JunitStrategy();
+  const parser = new LogParser([json, junit]);
+  const spy = vi.spyOn(json, 'parse');
+  const result = await parser.parseFile(jsonPath);
+  expect(spy).toHaveBeenCalled();
+  expect(result.errors.length).toBe(1);
+});
+
+test('LogParser selects JunitStrategy', async () => {
+  const xmlPath = tempFile('report.xml',
+    '<testsuite name="s" timestamp="t"><testcase name="a"><failure type="e" message="m">s</failure></testcase></testsuite>');
+  const json = new JsonStrategy();
+  const junit = new JunitStrategy();
+  const parser = new LogParser([json, junit]);
+  const spy = vi.spyOn(junit, 'parse');
+  const result = await parser.parseFile(xmlPath);
+  expect(spy).toHaveBeenCalled();
+  expect(result.errors.length).toBe(1);
+});

--- a/packages/log-parser/package.json
+++ b/packages/log-parser/package.json
@@ -26,9 +26,11 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w --preserveWatchOutput",
-    "lint": "eslint src --max-warnings=0"
+    "lint": "eslint src --max-warnings=0",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/log-parser/vitest.config.ts
+++ b/packages/log-parser/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@parser': resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Contexte et objectif
Ajout de tests unitaires dans `packages/log-parser` pour valider les stratégies `JsonStrategy` et `JunitStrategy` et vérifier la sélection de stratégie via `LogParser`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/log-parser build`
3. `pnpm test`

## Impact sur les autres modules
Aucun impact fonctionnel. Ajout d'un script `test` et de `vitest` en devDependency pour `log-parser`.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fc4f1a31083219a8ab6ec43ead0ed