### PR TITLE
[parser] XmlStrategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ export class LogAnalysisService {
 }
 ```
 
+### Ajouter une stratégie personnalisée
+
+```ts
+const parser = new LogParser();
+parser.registerStrategy(new XmlStrategy());
+```
+
 ## 📈 Collecte de métriques
 
 _TODO : exposer des métriques Prometheus depuis l'API._

--- a/packages/log-parser/index.ts
+++ b/packages/log-parser/index.ts
@@ -20,3 +20,4 @@ export { DefaultStrategy } from "./src/strategies/default-strategy.js";
 export { BaseStrategy } from "./src/strategies/base-strategy.js";
 export { JsonStrategy } from "./src/strategies/json-strategy.js";
 export { JunitStrategy } from "./src/strategies/junit-strategy.js";
+export { XmlStrategy } from "./src/strategies/xml-strategy.js";

--- a/packages/log-parser/src/strategies/xml-strategy.ts
+++ b/packages/log-parser/src/strategies/xml-strategy.ts
@@ -1,0 +1,40 @@
+import { ParsedLog, ExecutiveSummary, TestContext, LogError, MiscInfo } from "../types";
+import { BaseStrategy } from "./base-strategy";
+
+/**
+ * Example XmlStrategy
+ * -------------------
+ * Very naive XML parser to demonstrate extension of LogParser.
+ * Handles logs of the form:
+ *   <log scenario="s" date="d" environment="env" browser="b">
+ *     <error type="T" message="m">stack</error>
+ *   </log>
+ */
+export class XmlStrategy extends BaseStrategy {
+  canHandle(lines: string[]): boolean {
+    return lines.join(" ").includes("<log");
+  }
+
+  parse(lines: string[]): ParsedLog {
+    const xml = lines.join("\n");
+
+    const ctx: TestContext = {
+      scenario: xml.match(/scenario="([^"]+)"/)?.[1] ?? "",
+      date: xml.match(/date="([^"]+)"/)?.[1] ?? "",
+      environment: xml.match(/environment="([^"]+)"/)?.[1] ?? "",
+      browser: xml.match(/browser="([^"]+)"/)?.[1] ?? "",
+    };
+
+    const errors: LogError[] = [...xml.matchAll(/<error[^>]*type="([^"]+)"[^>]*message="([^"]+)"[^>]*>([^<]*)<\/error>/g)].map((m) => ({
+      type: m[1],
+      message: m[2],
+      stack: m[3].trim() || undefined,
+      lineNumber: 1,
+      raw: m[0],
+    }));
+
+    const summary: ExecutiveSummary = { text: this.execSummaryFrom(lines) };
+    const misc: MiscInfo = { versions: {}, apiEndpoints: [], testCases: [], folderIds: [] };
+    return { summary, context: ctx, errors, misc };
+  }
+}

--- a/packages/log-parser/xml-strategy.spec.ts
+++ b/packages/log-parser/xml-strategy.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test, vi } from 'vitest';
+import { LogParser } from '@parser/parser';
+import { XmlStrategy } from '@parser/strategies/xml-strategy';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function tempFile(name: string, content: string): string {
+  const p = join(tmpdir(), name);
+  writeFileSync(p, content);
+  return p;
+}
+
+test('registers and uses XmlStrategy', async () => {
+  const xmlPath = tempFile(
+    'sample.xml',
+    '<log scenario="s" date="d" environment="e" browser="b"><error type="E" message="boom">stack</error></log>'
+  );
+  const xml = new XmlStrategy();
+  const parser = new LogParser();
+  parser.registerStrategy(xml);
+  const spy = vi.spyOn(xml, 'parse');
+  const result = await parser.parseFile(xmlPath);
+  expect(spy).toHaveBeenCalled();
+  expect(result.context.scenario).toBe('s');
+  expect(result.errors.length).toBe(1);
+});


### PR DESCRIPTION
## Contexte et objectif
- illustrer l’extensibilité du `LogParser`
- fournir un exemple concret de stratégie supplémentaire
- mettre la doc en phase avec cette fonctionnalité

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/log-parser build`
3. `pnpm lint && pnpm test`

## Impact sur les autres modules
- aucun, stratégie ajoutée de façon optionnelle

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fc93019288321bc7598ea8e850fea