### PR TITLE
[tests] utilitaire tempDir

### DIFF
--- a/tests/helpers/tempDir.ts
+++ b/tests/helpers/tempDir.ts
@@ -1,0 +1,9 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function tempDir(prefix = 'testlog-') {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+  return { dir, cleanup };
+}

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,19 +1,23 @@
 import { LogParser } from "@testlog-inspector/log-parser";
 import { writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { tempDir } from "./helpers/tempDir";
 import { vi } from "vitest";
 
 describe("LogParser", () => {
-  const tmp = join(tmpdir(), "test.log");
+  let tmp: string;
+  let cleanup: () => void;
+  let dir: string;
+
+  beforeEach(() => {
+    ({ dir, cleanup } = tempDir("parser-"));
+    tmp = join(dir, "test.log");
+  });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    try {
-      // remove file quietly
-      writeFileSync(tmp, "");
-    } catch (_) {}
+    cleanup();
   });
 
   it("should parse a nominal log file using a single read", async () => {


### PR DESCRIPTION
## Contexte et objectif
- factoriser la création de répertoire temporaire dans les tests
- simplifier `parser.spec.ts` et `e2e-upload.spec.ts`

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/log-parser build`
3. `pnpm lint`
4. `pnpm test`

## Impact sur les autres modules
- aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fde1428d483219b2a65f7b2a60426