### PR TITLE
[web] utilités de style PDF

### DIFF
--- a/apps/web/src/__tests__/pdf-utils.test.ts
+++ b/apps/web/src/__tests__/pdf-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setHeading, setParagraph } from '../lib/pdf';
+
+describe('pdf utilities', () => {
+  it('apply heading and paragraph styles', () => {
+    const doc = {
+      setFontSize: vi.fn().mockReturnThis(),
+      setFont: vi.fn().mockReturnThis(),
+    };
+
+    // Heading
+    const returnedHeading = setHeading(doc);
+    expect(doc.setFontSize).toHaveBeenCalledWith(14);
+    expect(doc.setFont).toHaveBeenCalledWith('helvetica', 'bold');
+    expect(returnedHeading).toBe(doc);
+
+    doc.setFontSize.mockClear();
+    doc.setFont.mockClear();
+
+    // Paragraph
+    const returnedParagraph = setParagraph(doc);
+    expect(doc.setFontSize).toHaveBeenCalledWith(11);
+    expect(doc.setFont).toHaveBeenCalledWith('helvetica', 'normal');
+    expect(returnedParagraph).toBe(doc);
+  });
+});

--- a/apps/web/src/lib/JsPdfGenerator.ts
+++ b/apps/web/src/lib/JsPdfGenerator.ts
@@ -2,6 +2,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import type { ParsedLog } from '@testlog-inspector/log-parser';
 import type { IPdfGenerator } from './IPdfGenerator';
+import { setHeading, setParagraph } from './pdf';
 
 /**
  * Implémentation concrète de `IPdfGenerator` basée sur jsPDF.
@@ -15,13 +16,13 @@ export class JsPdfGenerator implements IPdfGenerator {
     let cursorY = margin;
 
     const addHeading = (text: string) => {
-      doc.setFontSize(14).setFont('helvetica', 'bold');
+      setHeading(doc);
       doc.text(text, margin, cursorY);
       cursorY += lineHeight + 4;
     };
 
     const addParagraph = (text: string) => {
-      doc.setFontSize(11).setFont('helvetica', 'normal');
+      setParagraph(doc);
       const splitted = doc.splitTextToSize(
         text,
         doc.internal.pageSize.getWidth() - margin * 2,

--- a/apps/web/src/lib/pdf.ts
+++ b/apps/web/src/lib/pdf.ts
@@ -1,0 +1,18 @@
+export interface FontUtils {
+  setFontSize(size: number): this;
+  setFont(family: string, style?: string): this;
+}
+
+/**
+ * Apply heading style to the current jsPDF instance.
+ */
+export function setHeading<T extends FontUtils>(doc: T): T {
+  return doc.setFontSize(14).setFont('helvetica', 'bold');
+}
+
+/**
+ * Apply paragraph style to the current jsPDF instance.
+ */
+export function setParagraph<T extends FontUtils>(doc: T): T {
+  return doc.setFontSize(11).setFont('helvetica', 'normal');
+}


### PR DESCRIPTION
## Contexte et objectif
- factorisation des appels `setFontSize`/`setFont` dans `JsPdfGenerator`
- ajout de tests unitaires pour les helpers PDF

## Étapes pour tester
1. `pnpm lint`
2. `pnpm turbo run test --filter @testlog-inspector/web`

## Impact sur les autres modules
- aucun, uniquement l'app web

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fe2e586f08321bbeb66409117fe6d