### PR TITLE
[api] factorisation des messages d'erreur

### DIFF
--- a/apps/api/src/common/error-messages.ts
+++ b/apps/api/src/common/error-messages.ts
@@ -1,0 +1,10 @@
+// Standardized error messages used across the API
+// ------------------------------------------------
+export const ERR_INVALID_FILETYPE =
+  'Invalid file type; only .log or .txt are accepted';
+
+export const ERR_FILE_TOO_LARGE = (limitMb: number) =>
+  `File exceeds the ${limitMb}\u00a0MB limit`;
+
+export const ERR_FILE_REQUIRED = 'file is required';
+export const ERR_NO_FILES = 'No files uploaded';

--- a/apps/api/src/log-analysis/file-validation.service.spec.ts
+++ b/apps/api/src/log-analysis/file-validation.service.spec.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from '@nestjs/common';
 import type { Express } from 'express';
 import { FileValidationService } from './file-validation.service';
 import { FileValidator } from './file-validator.service';
+import { ERR_FILE_REQUIRED } from '../common/error-messages';
 
 class MockFileValidator {
   validate = jest.fn();
@@ -33,7 +34,7 @@ describe('FileValidationService', () => {
   });
 
   it('should throw when file has no path', () => {
-    expect(() => service.validate({} as Express.Multer.File)).toThrow(BadRequestException);
+    expect(() => service.validate({} as Express.Multer.File)).toThrow(ERR_FILE_REQUIRED);
     expect(validator.validate).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/log-analysis/file-validation.service.ts
+++ b/apps/api/src/log-analysis/file-validation.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import type { Express } from 'express';
 import { FileValidator } from './file-validator.service';
+import { ERR_FILE_REQUIRED } from '../common/error-messages';
 
 /**
  * Coordinates all checks on the uploaded file before parsing.
@@ -12,7 +13,7 @@ export class FileValidationService {
 
   validate(file: Express.Multer.File): void {
     if (!file?.path) {
-      throw new BadRequestException('file is required');
+      throw new BadRequestException(ERR_FILE_REQUIRED);
     }
     this.validator.validate(file);
   }

--- a/apps/api/src/log-analysis/file-validator.service.ts
+++ b/apps/api/src/log-analysis/file-validator.service.ts
@@ -3,6 +3,10 @@ import { extname } from 'node:path';
 import type { Express } from 'express';
 import type { FileFilterCallback } from 'multer';
 import { MAX_UPLOAD_SIZE } from '../common/constants';
+import {
+  ERR_FILE_TOO_LARGE,
+  ERR_INVALID_FILETYPE,
+} from '../common/error-messages';
 
 /**
  * Service responsible for validating uploaded files.
@@ -16,12 +20,12 @@ export class FileValidator {
   validate(file: Express.Multer.File): void {
     const ext = extname(file.originalname).toLowerCase();
     if (!this.ALLOWED_EXT.includes(ext)) {
-      throw new BadRequestException('Invalid file type; only .log or .txt are accepted');
+      throw new BadRequestException(ERR_INVALID_FILETYPE);
     }
 
     if (file.size > this.MAX_SIZE) {
       const mb = Math.ceil(this.MAX_SIZE / (1024 * 1024));
-      throw new BadRequestException(`File exceeds the ${mb}\u00a0MB limit`);
+      throw new BadRequestException(ERR_FILE_TOO_LARGE(mb));
     }
   }
 }

--- a/apps/api/src/log-analysis/log-analysis.controller.ts
+++ b/apps/api/src/log-analysis/log-analysis.controller.ts
@@ -18,6 +18,7 @@ import type { Express } from 'express';
 
 import { ILogAnalysisService } from './ILogAnalysisService';
 import { ParsedLog } from '@testlog-inspector/log-parser';
+import { ERR_NO_FILES } from '../common/error-messages';
 
 /**
  * POST /analyze
@@ -50,7 +51,7 @@ export class LogAnalysisController {
     @UploadedFiles() files: Express.Multer.File[],
   ): Promise<ParsedLog[]> {
     if (!files?.length) {
-      throw new BadRequestException('No files uploaded');
+      throw new BadRequestException(ERR_NO_FILES);
     }
 
     const results: ParsedLog[] = [];

--- a/apps/api/src/log-analysis/upload.controller.ts
+++ b/apps/api/src/log-analysis/upload.controller.ts
@@ -18,6 +18,7 @@ import type { Express } from 'express';
 
 import { ILogAnalysisService } from './ILogAnalysisService';
 import { ParsedLog } from '@testlog-inspector/log-parser';
+import { ERR_NO_FILES } from '../common/error-messages';
 
 /**
  * POST /upload
@@ -46,7 +47,7 @@ export class UploadController {
     @UploadedFiles() files: Express.Multer.File[],
   ): Promise<ParsedLog[]> {
     if (!files?.length) {
-      throw new BadRequestException('No files uploaded');
+      throw new BadRequestException(ERR_NO_FILES);
     }
 
     const results: ParsedLog[] = [];

--- a/tests/e2e-upload.spec.ts
+++ b/tests/e2e-upload.spec.ts
@@ -15,6 +15,7 @@ import { tempDir } from './helpers/tempDir';
 
 import { AppModule } from '../apps/api/src/app.module';
 import { MAX_UPLOAD_SIZE } from '../apps/api/src/common/constants';
+import { ERR_FILE_TOO_LARGE } from '../apps/api/src/common/error-messages';
 
 describe('Upload log file (e2e)', () => {
   let app: INestApplication;
@@ -67,9 +68,12 @@ Browser: headless`,
   it('POST /analyze should enforce MAX_UPLOAD_SIZE', async () => {
     const oversized = Buffer.alloc(MAX_UPLOAD_SIZE + 1, '.');
 
-    await request(app.getHttpServer())
+    const res = await request(app.getHttpServer())
       .post('/analyze')
       .attach('files', oversized, 'big.log')
       .expect(400);
+
+    const mb = Math.ceil(MAX_UPLOAD_SIZE / (1024 * 1024));
+    expect(res.body.message).toBe(ERR_FILE_TOO_LARGE(mb));
   });
 });


### PR DESCRIPTION
## Contexte
Centralisation des messages d'erreur réutilisés dans l'API afin d'éviter les doublons et faciliter la maintenance.

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact
Aucun impact fonctionnel, uniquement la factorisation des messages et mise à jour des tests associés.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fe866ba548321b27a284019c1fe74