### PR TITLE
[tests] refactor setup helper

### DIFF
--- a/apps/web/src/__tests__/Dashboard.test.tsx
+++ b/apps/web/src/__tests__/Dashboard.test.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { renderWithProviders, screen } from '../../../../tests/helpers/renderWithProviders';
 
 import Dashboard from '@/components/Dashboard';
 import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
 
 describe('<Dashboard />', () => {
   it('renders without crashing and shows key sections', () => {
-    render(<Dashboard data={parsedLogFixture} />);
+    renderWithProviders(<Dashboard data={parsedLogFixture} />);
 
     // Résumé
     expect(screen.getByText('Résumé exécutif')).toBeInTheDocument();

--- a/apps/web/src/__tests__/ErrorTable.test.tsx
+++ b/apps/web/src/__tests__/ErrorTable.test.tsx
@@ -1,19 +1,18 @@
-import { render, screen, within } from '@testing-library/react';
+import { renderWithProviders, screen, within } from '../../../../tests/helpers/renderWithProviders';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom';
 
 import ErrorTable from '@/components/ErrorTable';
 import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
 
 describe('<ErrorTable />', () => {
   it('renders rows in ascending order by default', () => {
-    render(<ErrorTable errors={parsedLogFixture.errors} />);
+    renderWithProviders(<ErrorTable errors={parsedLogFixture.errors} />);
     const firstRow = within(screen.getAllByRole('row')[1]); // header = row[0]
     expect(firstRow.getByText('5')).toBeInTheDocument();
   });
 
   it('filters rows with global search input', async () => {
-    render(<ErrorTable errors={parsedLogFixture.errors} />);
+    renderWithProviders(<ErrorTable errors={parsedLogFixture.errors} />);
     const user = userEvent.setup();
 
     const filterInput = screen.getByPlaceholderText(/Filtrer…/i);

--- a/tests/helpers/renderWithProviders.tsx
+++ b/tests/helpers/renderWithProviders.tsx
@@ -1,0 +1,14 @@
+import { render, RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { JsPdfGenerator } from '../../apps/web/src/lib/JsPdfGenerator';
+import { PdfGeneratorProvider } from '../../apps/web/src/lib/PdfGeneratorContext';
+
+export function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
+  const generator = new JsPdfGenerator();
+  return render(
+    <PdfGeneratorProvider value={generator}>{ui}</PdfGeneratorProvider>,
+    options,
+  );
+}
+
+export * from '@testing-library/react';


### PR DESCRIPTION
## Contexte et objectif
- centraliser l'initialisation des providers React pour les tests
- réduire les imports répétitifs dans les tests du front

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm --filter @testlog-inspector/log-parser build`
4. `pnpm test`

## Impact sur les autres modules
- aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fece28fdc832196fcf44dd3ee407a