### PR TITLE
[web] Centralise pdf constants

### DIFF
--- a/apps/web/src/__tests__/pdf-utils.test.ts
+++ b/apps/web/src/__tests__/pdf-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { setHeading, setParagraph } from '../lib/pdf';
+import { PDF_CONFIG, setHeading, setParagraph } from '../lib/pdf';
 
 describe('pdf utilities', () => {
   it('apply heading and paragraph styles', () => {
@@ -10,8 +10,8 @@ describe('pdf utilities', () => {
 
     // Heading
     const returnedHeading = setHeading(doc);
-    expect(doc.setFontSize).toHaveBeenCalledWith(14);
-    expect(doc.setFont).toHaveBeenCalledWith('helvetica', 'bold');
+    expect(doc.setFontSize).toHaveBeenCalledWith(PDF_CONFIG.headingSize);
+    expect(doc.setFont).toHaveBeenCalledWith(PDF_CONFIG.fontFamily, 'bold');
     expect(returnedHeading).toBe(doc);
 
     doc.setFontSize.mockClear();
@@ -19,8 +19,8 @@ describe('pdf utilities', () => {
 
     // Paragraph
     const returnedParagraph = setParagraph(doc);
-    expect(doc.setFontSize).toHaveBeenCalledWith(11);
-    expect(doc.setFont).toHaveBeenCalledWith('helvetica', 'normal');
+    expect(doc.setFontSize).toHaveBeenCalledWith(PDF_CONFIG.paragraphSize);
+    expect(doc.setFont).toHaveBeenCalledWith(PDF_CONFIG.fontFamily, 'normal');
     expect(returnedParagraph).toBe(doc);
   });
 });

--- a/apps/web/src/lib/JsPdfGenerator.ts
+++ b/apps/web/src/lib/JsPdfGenerator.ts
@@ -2,7 +2,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import type { ParsedLog } from '@testlog-inspector/log-parser';
 import type { IPdfGenerator } from './IPdfGenerator';
-import { setHeading, setParagraph } from './pdf';
+import { PDF_CONFIG, setHeading, setParagraph } from './pdf';
 
 /**
  * Implémentation concrète de `IPdfGenerator` basée sur jsPDF.
@@ -11,14 +11,13 @@ import { setHeading, setParagraph } from './pdf';
 export class JsPdfGenerator implements IPdfGenerator {
   async generate(data: ParsedLog, filename = 'testlog-report.pdf'): Promise<void> {
     const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-    const margin = 40;
-    const lineHeight = 14;
+    const { margin, lineHeight, headingSpacing } = PDF_CONFIG;
     let cursorY = margin;
 
     const addHeading = (text: string) => {
       setHeading(doc);
       doc.text(text, margin, cursorY);
-      cursorY += lineHeight + 4;
+      cursorY += lineHeight + headingSpacing;
     };
 
     const addParagraph = (text: string) => {

--- a/apps/web/src/lib/pdf.ts
+++ b/apps/web/src/lib/pdf.ts
@@ -3,16 +3,30 @@ export interface FontUtils {
   setFont(family: string, style?: string): this;
 }
 
+/** Shared configuration for PDF generation. */
+export const PDF_CONFIG = {
+  margin: 40,
+  lineHeight: 14,
+  headingSize: 14,
+  paragraphSize: 11,
+  headingSpacing: 4,
+  fontFamily: 'helvetica',
+} as const;
+
 /**
  * Apply heading style to the current jsPDF instance.
  */
 export function setHeading<T extends FontUtils>(doc: T): T {
-  return doc.setFontSize(14).setFont('helvetica', 'bold');
+  return doc
+    .setFontSize(PDF_CONFIG.headingSize)
+    .setFont(PDF_CONFIG.fontFamily, 'bold');
 }
 
 /**
  * Apply paragraph style to the current jsPDF instance.
  */
 export function setParagraph<T extends FontUtils>(doc: T): T {
-  return doc.setFontSize(11).setFont('helvetica', 'normal');
+  return doc
+    .setFontSize(PDF_CONFIG.paragraphSize)
+    .setFont(PDF_CONFIG.fontFamily, 'normal');
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "precommit": "lint-staged"
   },
   "devDependencies": {
+    "@testing-library/react": "16.3.0",
     "@types/node": "^24.0.15",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
@@ -33,6 +34,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.2",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "ts-node": "^10.9.2",
     "turbo": "^2.5.5",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(jspdf@3.0.1)
     devDependencies:
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^24.0.15
         version: 24.0.15
@@ -51,6 +54,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.13.1(@swc/helpers@0.5.15))(@types/node@24.0.15)(typescript@5.8.3)


### PR DESCRIPTION
## Contexte et objectif
- centraliser `margin`, `lineHeight`… dans un seul objet partagé
- réutiliser ces constantes dans `JsPdfGenerator` et dans les tests

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
- ajout de dépendances `react`, `react-dom` et `@testing-library/react` au package racine pour exécuter les tests hors du dossier `apps/web`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687fee81571c8321975145b729005f99