### PR TITLE
[api] centralise ALLOWED_EXT constant

### DIFF
--- a/apps/api/src/common/file.constants.ts
+++ b/apps/api/src/common/file.constants.ts
@@ -1,0 +1,3 @@
+// Shared file-related constants
+// ------------------------------
+export const ALLOWED_EXT = ['.log', '.txt'] as const;

--- a/apps/api/src/log-analysis/file-validator.service.ts
+++ b/apps/api/src/log-analysis/file-validator.service.ts
@@ -3,6 +3,7 @@ import { extname } from 'node:path';
 import type { Express } from 'express';
 import type { FileFilterCallback } from 'multer';
 import { MAX_UPLOAD_SIZE } from '../common/constants';
+import { ALLOWED_EXT } from '../common/file.constants';
 import {
   ERR_FILE_TOO_LARGE,
   ERR_INVALID_FILETYPE,
@@ -15,11 +16,10 @@ import {
 @Injectable()
 export class FileValidator {
   private readonly MAX_SIZE = MAX_UPLOAD_SIZE;
-  private readonly ALLOWED_EXT = ['.log', '.txt'];
 
   validate(file: Express.Multer.File): void {
     const ext = extname(file.originalname).toLowerCase();
-    if (!this.ALLOWED_EXT.includes(ext)) {
+    if (!ALLOWED_EXT.includes(ext as (typeof ALLOWED_EXT)[number])) {
       throw new BadRequestException(ERR_INVALID_FILETYPE);
     }
 

--- a/apps/web/src/components/FileDropzone.tsx
+++ b/apps/web/src/components/FileDropzone.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useUpload } from "../hooks/useUpload";
 import { ParsedLog } from "@testlog-inspector/log-parser";
 import { Card } from "@testlog-inspector/ui-components";
+import { ALLOWED_EXT } from "../../../api/src/common/file.constants";
 
 export default function FileDropzone({
   onAnalyzed,
@@ -32,12 +33,12 @@ export default function FileDropzone({
       <p className="text-center">
         {isUploading
           ? "Analyse en cours…"
-          : "Glissez-déposez vos fichiers .log ou cliquez"}
+          : `Glissez-déposez vos fichiers ${ALLOWED_EXT.join(' ou ')} ou cliquez`}
       </p>
       <input
         type="file"
         multiple
-        accept=".txt,.log"
+        accept={ALLOWED_EXT.join(',')}
         className="hidden"
         onChange={(e) => upload(Array.from(e.target.files ?? []))}
       />


### PR DESCRIPTION
## Contexte et objectif
Un fichier `file.constants.ts` a été ajouté pour exposer la liste `ALLOWED_EXT` afin de la partager entre l’API et le frontend. `FileValidator` et `FileDropzone` réutilisent désormais cette constante.

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/log-parser build`
3. `pnpm lint`
4. `pnpm test`

## Impact sur les autres modules
Le frontend importe la constante depuis l’API pour afficher les extensions acceptées, aucune régression attendue.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687ff193bf808321aadb124774febd14