### PR TITLE
[docs] add help script

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ Les scripts `pnpm` fonctionnent également sous Windows via Git Bash ou WSL.
 Veillez à définir les variables d'environnement (`set NEXT_PUBLIC_API_URL=...`)
 suivant la syntaxe de votre terminal.
 
+Pour lister rapidement les commandes utiles :
+
+```bash
+pnpm run help
+```
+
 ## 🛠️ Fichiers de configuration
 
 - `package.json` : scripts communs (`dev`, `build`, `start`, `lint`, `test`).

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
     "test": "turbo run test",
     "ci": "turbo run lint build test --no-cache",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "help": "node scripts/help.js"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.0",

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+console.log(`
+Principales commandes pnpm :
+
+  pnpm lint   - vérifie la qualité du code
+  pnpm test   - exécute la suite de tests
+  pnpm dev    - lance l'environnement de développement
+`);


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un script `help` pour lister rapidement les principales commandes du projet et mise à jour de la documentation.

## Étapes pour tester
1. `pnpm run help` – affiche les commandes.
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
Aucun impact fonctionnel.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687ff3a008f48321a2c4c9a68c508a86