### PR TITLE
[web] simplify sorting

### DIFF
--- a/apps/web/src/__tests__/useUpload.test.ts
+++ b/apps/web/src/__tests__/useUpload.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useUpload } from '../hooks/useUpload';
 
 // Basic mock response
 function mockFetch() {
@@ -15,6 +14,7 @@ describe('useUpload', () => {
     const fetchMock = mockFetch();
     vi.stubGlobal('fetch', fetchMock);
 
+    const { useUpload } = await import('../hooks/useUpload');
     const { result } = renderHook(() => useUpload(() => {}));
 
     const file = new File(['data'], 'test.log');

--- a/apps/web/src/components/ErrorTable.tsx
+++ b/apps/web/src/components/ErrorTable.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { ColumnDef } from '@tanstack/react-table';
 import { LogError } from '@testlog-inspector/log-parser';
 
-import { SortableTable, Button, Card } from '@testlog-inspector/ui-components';
+import {
+  SortableTable,
+  Button,
+  Card,
+  type ColumnDef
+} from '@testlog-inspector/ui-components';
 
 interface Props {
   errors: LogError[];
@@ -25,26 +29,26 @@ export default function ErrorTable({ errors }: Props) {
       {
         accessorKey: 'type',
         header: 'Type',
-        cell: (info) => <span className="font-mono">{info.getValue<string>()}</span>,
+        cell: (value) => <span className="font-mono">{String(value)}</span>,
       },
       {
         accessorKey: 'message',
         header: 'Message',
-        cell: (info) => info.getValue<string>(),
+        cell: (value) => String(value),
       },
       {
         accessorKey: 'lineNumber',
         header: 'Ligne',
-        cell: (info) => info.getValue<number>(),
+        cell: (value) => String(value),
       },
       {
-        id: 'actions',
         header: '',
-        cell: ({ row }) => {
-          const id = row.id;
+        sortable: false,
+        cell: (_, row, idx) => {
+          const id = String(idx);
           const isOpen = expanded === id;
 
-          return row.original.stack ? (
+          return row.stack ? (
             <Button
               variant="ghost"
               size="sm"
@@ -66,7 +70,7 @@ export default function ErrorTable({ errors }: Props) {
       <SortableTable
         data={errors}
         columns={columns}
-        initialSort={[{ id: 'lineNumber', desc: false }]}
+        initialSort={{ key: 'lineNumber', desc: false }}
         filterKeys={['type', 'message']}
       />
 

--- a/packages/ui-components/src/SortableTable.tsx
+++ b/packages/ui-components/src/SortableTable.tsx
@@ -1,20 +1,23 @@
 import * as React from "react";
-import {
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
-  ColumnDef,
-  SortingState,
-} from "@tanstack/react-table";
-
 import { Table, TableHead, TableHeader, TableRow, TableCell } from "./shadcn/Table";
 import { Input } from "./shadcn/Input";
 
+export interface ColumnDef<TData> {
+  accessorKey?: keyof TData;
+  header: React.ReactNode;
+  cell?: (value: TData[keyof TData] | undefined, row: TData, index: number) => React.ReactNode;
+  sortable?: boolean;
+}
+
+export interface SortConfig<TData> {
+  key: keyof TData;
+  desc: boolean;
+}
+
 export interface SortableTableProps<TData extends object> {
   data: TData[];
-  columns: ColumnDef<TData, any>[];
-  initialSort?: SortingState;
+  columns: ColumnDef<TData>[];
+  initialSort?: SortConfig<TData>;
   filterKeys?: (keyof TData)[];
 }
 
@@ -24,26 +27,36 @@ export function SortableTable<TData extends object>({
   initialSort,
   filterKeys = [],
 }: SortableTableProps<TData>) {
-  const [sorting, setSorting] = React.useState<SortingState>(initialSort ?? []);
+  const [sort, setSort] = React.useState<SortConfig<TData> | undefined>(initialSort);
   const [globalFilter, setGlobalFilter] = React.useState("");
 
-  const table = useReactTable({
-    data,
-    columns,
-    state: { sorting, globalFilter },
-    onSortingChange: setSorting,
-    globalFilterFn: (row, colId, filter) => {
-      if (!filter) return true;
-      const keys = filterKeys.length ? filterKeys : (Object.keys(row.original) as (keyof TData)[]);
-      return keys.some((k) =>
-        String(row.original[k] ?? "")
-          .toLowerCase()
-          .includes(String(filter).toLowerCase()),
-      );
-    },
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
+  const handleSort = (key?: keyof TData) => {
+    if (!key) return;
+    setSort((prev) =>
+      prev && prev.key === key ? { key, desc: !prev.desc } : { key, desc: false },
+    );
+  };
+
+  const filtered = React.useMemo(() => {
+    if (!globalFilter) return data;
+    const keys = filterKeys.length ? filterKeys : (Object.keys(data[0] ?? {}) as (keyof TData)[]);
+    const lower = globalFilter.toLowerCase();
+    return data.filter((row) =>
+      keys.some((k) => String(row[k] ?? "").toLowerCase().includes(lower)),
+    );
+  }, [data, globalFilter, filterKeys]);
+
+  const sorted = React.useMemo(() => {
+    if (!sort) return filtered;
+    return [...filtered].sort((a, b) => {
+      const av = a[sort.key];
+      const bv = b[sort.key];
+      if (av === bv) return 0;
+      if (av === undefined || av === null) return 1;
+      if (bv === undefined || bv === null) return -1;
+      return av > bv ? (sort.desc ? -1 : 1) : sort.desc ? 1 : -1;
+    });
+  }, [filtered, sort]);
 
   return (
     <div className="space-y-2">
@@ -56,37 +69,30 @@ export function SortableTable<TData extends object>({
 
       <Table>
         <TableHeader>
-          {table.getHeaderGroups().map((hg) => (
-            <TableRow key={hg.id}>
-              {hg.headers.map((header) => (
-                <TableHead
-                  key={header.id}
-                  onClick={header.column.getToggleSortingHandler()}
-                  className="cursor-pointer select-none"
-                >
-                  {flexRender(
-                    header.column.columnDef.header,
-                    header.getContext()
-                  ) as React.ReactNode}
-                  {{
-                    asc: " ▲",
-                    desc: " ▼",
-                  }[header.column.getIsSorted() as string] ?? null}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
+          <TableRow>
+            {columns.map((col) => (
+              <TableHead
+                key={String(col.accessorKey ?? col.header)}
+                onClick={col.sortable === false ? undefined : () => handleSort(col.accessorKey)}
+                className={col.sortable === false ? undefined : "cursor-pointer select-none"}
+              >
+                {col.header}
+                {col.accessorKey && sort?.key === col.accessorKey ? (sort.desc ? " ▼" : " ▲") : null}
+              </TableHead>
+            ))}
+          </TableRow>
         </TableHeader>
 
         <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(
-                    cell.column.columnDef.cell,
-                    cell.getContext()
-                  ) as React.ReactNode}
+          {sorted.map((row, idx) => (
+            <TableRow key={idx}>
+              {columns.map((col) => (
+                <TableCell key={String(col.accessorKey ?? col.header)}>
+                  {col.cell
+                    ? col.cell(col.accessorKey ? row[col.accessorKey] : undefined, row, idx)
+                    : col.accessorKey
+                    ? ((row[col.accessorKey] as React.ReactNode) ?? null)
+                    : null}
                 </TableCell>
               ))}
             </TableRow>

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -13,5 +13,5 @@ export { Badge } from "./shadcn/Badge";
 export { Input } from "./shadcn/Input";
 export { Table, TableHeader, TableRow, TableCell, TableHead } from "./shadcn/Table";
 
-export { SortableTable } from "./SortableTable";
+export { SortableTable, type ColumnDef, type SortConfig } from "./SortableTable";
 export { SortableTable as DataTable } from "./SortableTable";


### PR DESCRIPTION
## Contexte
- simplifie le tableau triable en triant via `Array.sort`
- unifie la logique avec une fonction `handleSort`
- ajuste ErrorTable et les tests

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact
- UI web uniquement, aucun impact sur l’API

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68800091ea9c8321b2220f1a7e63618e