### PR TITLE
[api] streamline analysis flow

### DIFF
--- a/apps/api/src/log-analysis/file-validation.service.ts
+++ b/apps/api/src/log-analysis/file-validation.service.ts
@@ -12,9 +12,8 @@ export class FileValidationService {
   constructor(private readonly validator: FileValidator) {}
 
   validate(file: Express.Multer.File): void {
-    if (!file?.path) {
-      throw new BadRequestException(ERR_FILE_REQUIRED);
-    }
+    if (!file?.path) throw new BadRequestException(ERR_FILE_REQUIRED);
+
     this.validator.validate(file);
   }
 }

--- a/apps/api/src/log-analysis/log-analysis.controller.ts
+++ b/apps/api/src/log-analysis/log-analysis.controller.ts
@@ -54,13 +54,6 @@ export class LogAnalysisController {
       throw new BadRequestException(ERR_NO_FILES);
     }
 
-    const results: ParsedLog[] = [];
-
-    for (const file of files) {
-      const parsed = await this.service.analyze(file);
-      results.push(parsed);
-    }
-
-    return results;
+    return Promise.all(files.map((file) => this.service.analyze(file)));
   }
 }

--- a/apps/api/src/log-analysis/log-analysis.service.ts
+++ b/apps/api/src/log-analysis/log-analysis.service.ts
@@ -16,6 +16,7 @@ export class LogAnalysisService implements ILogAnalysisService {
   async analyze(file: Express.Multer.File): Promise<ParsedLog> {
     this.validator.validate(file);
 
+    // Parse the file and convert parser errors into HTTP 400
     try {
       return await this.parser.parseFile(file.path);
     } catch (err) {

--- a/apps/api/src/log-analysis/upload.controller.ts
+++ b/apps/api/src/log-analysis/upload.controller.ts
@@ -50,13 +50,6 @@ export class UploadController {
       throw new BadRequestException(ERR_NO_FILES);
     }
 
-    const results: ParsedLog[] = [];
-
-    for (const file of files) {
-      const parsed = await this.service.analyze(file);
-      results.push(parsed);
-    }
-
-    return results;
+    return Promise.all(files.map((file) => this.service.analyze(file)));
   }
 }


### PR DESCRIPTION
## Contexte et objectif
Simplifie la validation et l'analyse des fichiers côté API. La validation retourne directement une erreur si `file.path` est absent et les contrôleurs utilisent désormais `Promise.all` pour traiter les fichiers.

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
Aucun impact attendu en dehors de l'API.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688004defbcc832186218dc1b3fb5443