### PR TITLE
[log-parser] extraction lecture de fichier

### DIFF
--- a/packages/log-parser/index.ts
+++ b/packages/log-parser/index.ts
@@ -13,6 +13,7 @@
  */
 
 export * from "./src/parser.js";
+export { readFileContent } from "./src/parser.js";
 export * from "./src/types.js";
 export * from "./src/ILogParser.js";
 

--- a/packages/log-parser/src/parser.ts
+++ b/packages/log-parser/src/parser.ts
@@ -6,6 +6,18 @@ import fs from "node:fs/promises";
 import { IParsingStrategy, ParsedLog } from "./types";
 import { DefaultStrategy } from "./strategies/default-strategy";
 
+/**
+ * Read a file and return its content using UTF-8 encoding.
+ *
+ * @param path Absolute or relative file path
+ * @throws Error when the file cannot be read
+ */
+export async function readFileContent(path: string): Promise<string> {
+  return fs.readFile(path, "utf-8").catch((e) => {
+    throw new Error(`Unable to read file "${path}" — ${(e as Error).message}`);
+  });
+}
+
 export class LogParser {
   private strategies: IParsingStrategy[] = [];
 
@@ -28,12 +40,7 @@ export class LogParser {
    */
   async parseFile(path: string): Promise<ParsedLog> {
     if (!path) throw new Error("No file path provided");
-    let content = "";
-    try {
-      content = await fs.readFile(path, "utf-8");
-    } catch (e) {
-      throw new Error(`Unable to read file "${path}" — ${(e as Error).message}`);
-    }
+    const content = await readFileContent(path);
 
     const lines = content.split(/\r?\n/);
     const strategy =

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,4 +1,4 @@
-import { LogParser } from "@testlog-inspector/log-parser";
+import { LogParser, readFileContent } from "@testlog-inspector/log-parser";
 import { writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -18,6 +18,12 @@ describe("LogParser", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     cleanup();
+  });
+
+  it("readFileContent returns file content", async () => {
+    writeFileSync(tmp, "abc");
+    const res = await readFileContent(tmp);
+    expect(res).toContain("abc");
   });
 
   it("should parse a nominal log file using a single read", async () => {


### PR DESCRIPTION
## Contexte et objectif
Simplifie `LogParser.parseFile` en isolant la lecture du fichier dans une fonction dédiée `readFileContent`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm --filter @testlog-inspector/log-parser build`
3. `pnpm lint && pnpm test`

## Impact sur les autres modules
Aucun impact attendu : l’API publique du parseur reste inchangée.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688008b3cef483219fca3e2ada961c2f