### PR TITLE
[log-parser] tl-inspect CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ L'analyse peut être déclenchée via l'API REST :
 curl -F "files=@path/to/test.log" http://localhost:3001/analyze
 ```
 
+### Ligne de commande
+
+Le package `@testlog-inspector/log-parser` expose également un outil CLI nommé
+`tl-inspect`. Vous pouvez l'utiliser directement via `npx` :
+
+```bash
+npx tl-inspect path/to/file.log
+```
+
+La sortie correspond au `ParsedLog` au format JSON.
+
 ## 🔌 Injection de dépendances
 
 ```ts

--- a/packages/log-parser/bin/tl-inspect
+++ b/packages/log-parser/bin/tl-inspect
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { LogParser } = require('../dist/index.js');
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: tl-inspect <file.log>');
+    process.exit(1);
+  }
+
+  try {
+    const parser = new LogParser();
+    const result = await parser.parseFile(file);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/log-parser/package.json
+++ b/packages/log-parser/package.json
@@ -21,8 +21,12 @@
     "./*": "./dist/*"
   },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
+  "bin": {
+    "tl-inspect": "./bin/tl-inspect"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json -w --preserveWatchOutput",


### PR DESCRIPTION
## Contexte et objectif
Ajoute un petit outil CLI `tl-inspect` dans le package `log-parser` afin de parser un fichier directement depuis la ligne de commande.

## Étapes pour tester
1. `pnpm install`
2. `pnpm build --filter @testlog-inspector/log-parser`
3. `npx tl-inspect path/to/file.log`
4. Vérifier l'affichage du JSON `ParsedLog`.

## Impact sur les autres modules
Aucun, le binaire est fourni dans le package `log-parser`.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68800d2a966c83218f4792908932dc13