### PR TITLE
[api] centralize env configuration

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -14,3 +14,5 @@ Each variable has a sensible default so the stack runs out‑of‑the‑box.
 | `CI` | *unset* | When defined, Playwright will not reuse an existing dev server. |
 
 These variables can be provided via `.env` files or your host environment.
+The NestJS API reads them via `getConfig()` defined in
+[apps/api/src/common/config.ts](apps/api/src/common/config.ts).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Les principales variables de configuration sont décrites dans
 [ENVIRONMENT.md](./ENVIRONMENT.md). Par défaut, l'API NestJS est exposée sur
 `http://localhost:3001` et le frontend pointe vers cette URL via
 `NEXT_PUBLIC_API_URL`.
+La lecture de ces variables côté API est centralisée dans
+[apps/api/src/common/config.ts](apps/api/src/common/config.ts).
 
 `MAX_UPLOAD_SIZE` permet d'ajuster la taille maximale autorisée pour les requêtes
 et les fichiers envoyés (50 Mo par défaut).

--- a/apps/api/src/common/config.ts
+++ b/apps/api/src/common/config.ts
@@ -1,0 +1,33 @@
+export interface ApiConfig {
+  /** Port on which the Nest application listens. */
+  port: number;
+  /** Allowed origin for CORS requests. */
+  corsOrigin: string;
+  /** Maximum upload size in bytes (used by Multer & body parser). */
+  maxUploadSize: number;
+}
+
+/**
+ * Reads environment variables and returns normalized API configuration.
+ * Defaults mirror the values documented in ENVIRONMENT.md.
+ */
+export function getConfig(): ApiConfig {
+  const {
+    PORT,
+    CORS_ORIGIN,
+    MAX_UPLOAD_SIZE,
+    UPLOAD_LIMIT_MB,
+  } = process.env;
+
+  const port = PORT ? Number(PORT) : 3001;
+  const corsOrigin = CORS_ORIGIN ?? 'http://localhost:3000';
+
+  const defaultSize = 50 * 1024 * 1024; // 50MB
+  const maxUploadSize = MAX_UPLOAD_SIZE
+    ? Number(MAX_UPLOAD_SIZE)
+    : UPLOAD_LIMIT_MB
+    ? Number(UPLOAD_LIMIT_MB) * 1024 * 1024
+    : defaultSize;
+
+  return { port, corsOrigin, maxUploadSize };
+}

--- a/apps/api/src/common/constants.ts
+++ b/apps/api/src/common/constants.ts
@@ -1,9 +1,9 @@
 // Global constants for the API
 // -----------------------------
-// Max upload size in bytes (default 50MB), overridable via env var
-export const MAX_UPLOAD_SIZE = process.env.MAX_UPLOAD_SIZE
-  ? Number(process.env.MAX_UPLOAD_SIZE)
-  : 50 * 1024 * 1024;
+import { getConfig } from './config';
+
+// Max upload size in bytes (default 50MB)
+export const MAX_UPLOAD_SIZE = getConfig().maxUploadSize;
 
 // Express body-parser expects bytes when using a numeric limit
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet';
 
 import { AppModule } from './app.module';
 import { MAX_UPLOAD_SIZE } from './common/constants';
+import { getConfig } from './common/config';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -29,13 +30,14 @@ async function bootstrap() {
     }),
   );
 
+  const { port, corsOrigin } = getConfig();
+
   /* ---------- CORS (Next.js on :3000) ---------- */
   app.enableCors({
-    origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
+    origin: corsOrigin,
     credentials: true,
   });
 
-  const port = process.env.PORT ? Number(process.env.PORT) : 3001;
   await app.listen(port);
   logger.log(`🚀  API TestLog Inspector running on http://localhost:${port}`);
 }


### PR DESCRIPTION
## Contexte et objectif
Centralisation de la lecture des variables d'environnement pour l'API afin de simplifier la configuration. Une fonction `getConfig()` récupère désormais `PORT`, `CORS_ORIGIN` et `MAX_UPLOAD_SIZE`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm --filter @testlog-inspector/log-parser build`
4. `pnpm test`

## Impact sur les autres modules
Aucun impact attendu hors de l'API.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68800f0ddcd883219a5186e73a473b2e