### PR TITLE
[web] simplify PdfButton behavior

### DIFF
--- a/apps/web/src/__tests__/PdfButton.test.tsx
+++ b/apps/web/src/__tests__/PdfButton.test.tsx
@@ -1,21 +1,26 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 
-import PdfButton from '@/components/PdfButton';
-import { PdfGeneratorProvider } from '@/lib/PdfGeneratorContext';
-import type { IPdfGenerator } from '@/lib/IPdfGenerator';
-import { ParsedLog } from '@testlog-inspector/log-parser';
+import PdfButton from "@/components/PdfButton";
+import { PdfGeneratorProvider } from "@/lib/PdfGeneratorContext";
+import type { IPdfGenerator } from "@/lib/IPdfGenerator";
+import { ParsedLog } from "@testlog-inspector/log-parser";
 
 const sample: ParsedLog = {
-  summary: { text: 'Résumé' },
-  context: { scenario: 's1', date: '2025-01-01', environment: 'dev', browser: 'chrome' },
+  summary: { text: "Résumé" },
+  context: {
+    scenario: "s1",
+    date: "2025-01-01",
+    environment: "dev",
+    browser: "chrome",
+  },
   errors: [],
   misc: { versions: {}, apiEndpoints: [], testCases: [], folderIds: [] },
 };
 
-describe('<PdfButton />', () => {
-  it('calls the injected generator on click', async () => {
+describe("<PdfButton />", () => {
+  it("calls the injected generator on click", async () => {
     const generateMock = vi.fn();
     const providerValue: IPdfGenerator = { generate: generateMock };
     render(
@@ -24,7 +29,30 @@ describe('<PdfButton />', () => {
       </PdfGeneratorProvider>,
     );
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole("button"));
     expect(generateMock).toHaveBeenCalledWith(sample);
+  });
+
+  it("disables the button while generating", async () => {
+    let done!: () => void;
+    const generateMock = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          done = resolve;
+        }),
+    );
+    const providerValue: IPdfGenerator = { generate: generateMock };
+    render(
+      <PdfGeneratorProvider value={providerValue}>
+        <PdfButton data={sample} />
+      </PdfGeneratorProvider>,
+    );
+    const user = userEvent.setup();
+    const button = screen.getByRole("button");
+
+    await user.click(button);
+    expect(button).toBeDisabled();
+    done();
+    await waitFor(() => expect(button).not.toBeDisabled());
   });
 });

--- a/apps/web/src/components/PdfButton.tsx
+++ b/apps/web/src/components/PdfButton.tsx
@@ -1,9 +1,8 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { ParsedLog } from '@testlog-inspector/log-parser';
-import { Button } from '@testlog-inspector/ui-components';
-import { usePdfGenerator } from '@/lib/PdfGeneratorContext';
+import { ParsedLog } from "@testlog-inspector/log-parser";
+import { Button } from "@testlog-inspector/ui-components";
+import { usePdfGenerator } from "@/lib/PdfGeneratorContext";
 
 interface Props {
   data: ParsedLog;
@@ -14,21 +13,14 @@ interface Props {
  * L'implémentation concrète peut être remplacée en tests.
  */
 export default function PdfButton({ data }: Props) {
-  const [loading, setLoading] = useState(false);
   const pdf = usePdfGenerator();
 
-  const onClick = async () => {
-    try {
-      setLoading(true);
-      await pdf.generate(data);
-    } finally {
-      setLoading(false);
-    }
+  const onClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const btn = e.currentTarget;
+    btn.disabled = true;
+    await pdf.generate(data);
+    btn.disabled = false;
   };
 
-  return (
-    <Button onClick={onClick} disabled={loading}>
-      {loading ? 'Génération…' : 'Télécharger rapport PDF'}
-    </Button>
-  );
+  return <Button onClick={onClick}>Télécharger rapport PDF</Button>;
 }


### PR DESCRIPTION
## Contexte et objectif
- simplifier `PdfButton` en supprimant l'état React
- désactiver le bouton directement dans la fonction `async`
- ajouter un test s'assurant que le bouton est bien désactivé pendant l'appel

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact sur les autres modules
- aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68801127d6f08321a0307c716b22d18f