### PR TITLE
[docs] corrige cycle de lecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ graph TD
     A1 -- drag & drop .log --> B1
     B1 -- POST multipart /analyze --> C1
     C1 --> C2
-    C2 -- 5× read --> D1
+    C2 -- 1× read --> D1
     D1 --> D2 & D3 & D4
     D1 -- ParsedLog JSON --> C2
     C2 --> C1
@@ -208,8 +208,7 @@ if (file.size > this.MAX_SIZE) {
 
 ## 📊 Contraintes de performance
 
-Le parser lit chaque fichier cinq fois pour simuler des passes lourdes. Prévoyez
-en conséquence pour de très gros fichiers.
+Le parser lit chaque fichier une seule fois pour optimiser les performances.
 
 ## 📁 Structure du projet
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ graph TD
     A1 -- drag & drop .log --> B1
     B1 -- POST multipart /analyze --> C1
     C1 --> C2
-    C2 -- 5× read --> D1
+    C2 -- 1× read --> D1
     D1 --> D2 & D3 & D4
     D1 -- ParsedLog JSON --> C2
     C2 --> C1
@@ -45,7 +45,7 @@ graph TD
 | --------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
 | Upload Front → API    | Fichier > 50 Mo, mauvais type, réseau coupé    | **Multer** + `fileFilter` + limite taille 50 Mo ; message clair UI   |
 | Lecture fichier (API) | I/O error, fichier verrouillé, chemin invalide | Try/catch → `BadRequestException` ; logs Nest                        |
-| Parsing (5 passes)    | Format inconnu, JSON/XML corrompu              | Strategy fallback (`DefaultStrategy`) + tests unitaires              |
+| Parsing (1 pass)    | Format inconnu, JSON/XML corrompu              | Strategy fallback (`DefaultStrategy`) + tests unitaires              |
 | Retour JSON           | Payload massif → latence                       | Taille limitée ; résumé ≤ 300 mots ; pas de stack complète dans JSON |
 | Rendering React       | Data manquante / undefined                     | Checks `if (!data)` dans composants ; Prop Types stricts             |
 | Export PDF            | jsPDF erreur de police ou overflow             | `try/catch` + bouton désactivé (`loading`)                           |


### PR DESCRIPTION
## Contexte et objectif
- La documentation mentionnait un parsing en "5× read" qui n'est plus d'actualité.
- Le code effectue déjà une seule lecture du fichier.
- Mise à jour des schémas et explications associées.

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

## Impact sur les autres modules
- Aucun impact fonctionnel, uniquement documentation.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880983558b0832182546f2df60b9088