### PR TITLE
[docs] Nettoyage des variables d'environnement

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -8,7 +8,6 @@ Each variable has a sensible default so the stack runs out‑of‑the‑box.
 | `NEXT_PUBLIC_API_URL` | `http://localhost:3001` | Base URL for the NestJS API used by the Next.js frontend. `useUpload` builds its POST endpoint from this value. |
 | `PORT` | `3001` | Port on which the NestJS API listens. |
 | `CORS_ORIGIN` | `http://localhost:3000` | Allowed origin for CORS requests to the API. |
-| `NODE_ENV` | `development` | Node runtime environment. |
 | `MAX_UPLOAD_SIZE` | `52428800` | Maximum size in bytes for uploads and JSON bodies (50MB default). |
 | `UPLOAD_LIMIT_MB` | `50` | Alternate way to set the maximum upload size in megabytes. |
 | `CI` | *unset* | When defined, Playwright will not reuse an existing dev server. |

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ Les principales variables de configuration sont décrites dans
 La lecture de ces variables côté API est centralisée dans
 [apps/api/src/common/config.ts](apps/api/src/common/config.ts).
 
-`MAX_UPLOAD_SIZE` permet d'ajuster la taille maximale autorisée pour les requêtes
-et les fichiers envoyés (50 Mo par défaut).
-Vous pouvez aussi définir `UPLOAD_LIMIT_MB` pour spécifier la limite directement
-en mégaoctets (`UPLOAD_LIMIT_MB=100` autorise 100 Mo).
+Variables utilisées :
+
+- `NEXT_PUBLIC_API_URL` – URL de base pour l'API.
+- `PORT` – port d'écoute de l'API.
+- `CORS_ORIGIN` – origine autorisée pour CORS.
+- `MAX_UPLOAD_SIZE` ou `UPLOAD_LIMIT_MB` – taille maximale d'envoi.
+- `CI` – empêche Playwright de réutiliser un serveur local.
 
 ---
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -9,8 +9,6 @@ declare namespace NodeJS {
     /** URL publique de l’API Nest (ex. http://localhost:3001) */
     readonly NEXT_PUBLIC_API_URL?: string;
 
-    /** Environnement d’exécution */
-    readonly NODE_ENV: "development" | "production" | "test";
 
     /** Max upload size in bytes for Multer and body parsing (default 50MB) */
     readonly MAX_UPLOAD_SIZE?: string;


### PR DESCRIPTION
### Contexte et objectif
Nettoyage de la documentation et des types en retirant la variable `NODE_ENV`, non utilisée dans le code.

### Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

### Impact sur les autres modules
Aucun impact fonctionnel, uniquement la documentation et les types.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688099baf8f083219f12ed323fcd386f