### PR TITLE
[config] API_PORT var everywhere

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -6,7 +6,7 @@ Each variable has a sensible default so the stack runs out‑of‑the‑box.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `NEXT_PUBLIC_API_URL` | `http://localhost:3001` | Base URL for the NestJS API used by the Next.js frontend. `useUpload` builds its POST endpoint from this value. |
-| `PORT` | `3001` | Port on which the NestJS API listens. |
+| `API_PORT` | `3001` | Port on which the NestJS API listens. |
 | `CORS_ORIGIN` | `http://localhost:3000` | Allowed origin for CORS requests to the API. |
 | `MAX_UPLOAD_SIZE` | `52428800` | Maximum size in bytes for uploads and JSON bodies (50MB default). |
 | `UPLOAD_LIMIT_MB` | `50` | Alternate way to set the maximum upload size in megabytes. |

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ La lecture de ces variables côté API est centralisée dans
 
 Variables utilisées :
 
-- `NEXT_PUBLIC_API_URL` – URL de base pour l'API.
-- `PORT` – port d'écoute de l'API.
+- `NEXT_PUBLIC_API_URL` – URL de base pour l'API côté frontend.
+- `API_PORT` – port d'écoute de l'API.
 - `CORS_ORIGIN` – origine autorisée pour CORS.
 - `MAX_UPLOAD_SIZE` ou `UPLOAD_LIMIT_MB` – taille maximale d'envoi.
 - `CI` – empêche Playwright de réutiliser un serveur local.

--- a/apps/api/src/common/config.ts
+++ b/apps/api/src/common/config.ts
@@ -13,13 +13,13 @@ export interface ApiConfig {
  */
 export function getConfig(): ApiConfig {
   const {
-    PORT,
+    API_PORT,
     CORS_ORIGIN,
     MAX_UPLOAD_SIZE,
     UPLOAD_LIMIT_MB,
   } = process.env;
 
-  const port = PORT ? Number(PORT) : 3001;
+  const port = API_PORT ? Number(API_PORT) : 3001;
   const corsOrigin = CORS_ORIGIN ?? 'http://localhost:3000';
 
   const defaultSize = 50 * 1024 * 1024; // 50MB

--- a/env.d.ts
+++ b/env.d.ts
@@ -12,5 +12,8 @@ declare namespace NodeJS {
 
     /** Max upload size in bytes for Multer and body parsing (default 50MB) */
     readonly MAX_UPLOAD_SIZE?: string;
+
+    /** Port for the NestJS API (default 3001) */
+    readonly API_PORT?: string;
   }
 }


### PR DESCRIPTION
## Contexte et objectif
Renommage de la variable d'environnement pour le port de l'API afin d'utiliser `API_PORT`. Mise à jour du code et de la documentation pour refléter ce changement et s'assurer que le front continue d'utiliser `NEXT_PUBLIC_API_URL`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm lint`
3. `pnpm --filter @testlog-inspector/log-parser build`
4. `pnpm test`

## Impact sur les autres modules
Aucun impact fonctionnel ; seules les variables d'environnement changent de nom.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880ad51fc408321a93b61b6add71e97