### PR TITLE
[config] ajout d'aliases tsconfig

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ graph TD
 | --------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
 | Upload Front → API    | Fichier > 50 Mo, mauvais type, réseau coupé    | **Multer** + `fileFilter` + limite taille 50 Mo ; message clair UI   |
 | Lecture fichier (API) | I/O error, fichier verrouillé, chemin invalide | Try/catch → `BadRequestException` ; logs Nest                        |
-| Parsing (1 pass)    | Format inconnu, JSON/XML corrompu              | Strategy fallback (`DefaultStrategy`) + tests unitaires              |
+| Parsing (1 pass)      | Format inconnu, JSON/XML corrompu              | Strategy fallback (`DefaultStrategy`) + tests unitaires              |
 | Retour JSON           | Payload massif → latence                       | Taille limitée ; résumé ≤ 300 mots ; pas de stack complète dans JSON |
 | Rendering React       | Data manquante / undefined                     | Checks `if (!data)` dans composants ; Prop Types stricts             |
 | Export PDF            | jsPDF erreur de police ou overflow             | `try/catch` + bouton désactivé (`loading`)                           |
@@ -54,14 +54,23 @@ graph TD
 
 ## Découplage SOLID
 
-* **SRP** : chaque bloc ci‑dessus assure une seule responsabilité.
-* **OCP** : nouvelles stratégies parsing plug‑and‑play (`registerStrategy()`).
-* **DIP** : API dépend de l’interface `LogParser`, non des stratégies concrètes.
-* **Maintenance** : la pipe `ParseFilePipe` a été supprimée au profit du service `FileValidationService` pour centraliser la validation des uploads.
+- **SRP** : chaque bloc ci‑dessus assure une seule responsabilité.
+- **OCP** : nouvelles stratégies parsing plug‑and‑play (`registerStrategy()`).
+- **DIP** : API dépend de l’interface `LogParser`, non des stratégies concrètes.
+- **Maintenance** : la pipe `ParseFilePipe` a été supprimée au profit du service `FileValidationService` pour centraliser la validation des uploads.
+
+## Aliases TypeScript
+
+Le fichier `tsconfig.base.json` définit deux raccourcis communs :
+
+- `@/…` vers le dossier `src` du projet courant ;
+- `@testlog-inspector/…` vers les packages du monorepo.
+
+Chaque package ou application étend ce fichier pour bénéficier automatiquement de ces résolutions.
 
 ---
 
-*Générez la spécification OpenAPI à tout moment :*
+_Générez la spécification OpenAPI à tout moment :_
 
 ```bash
 pnpm -C apps/api run swagger:json   # => docs/api.openapi.json

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,12 +14,12 @@ module.exports = {
       transform: {
         '^.+\\.ts$': [
           'ts-jest',
-          { tsconfig: '<rootDir>/tsconfig.json', useESM: true }
+          { tsconfig: '<rootDir>/tsconfig.json', useESM: true },
         ],
       },
       extensionsToTreatAsEsm: ['.ts'],
       moduleNameMapper: {
-        '^@testlog-inspector/(.*)$': '<rootDir>/../../packages/$1',
+        '^@testlog-inspector/(.*)$': '<rootDir>/../../packages/$1/src',
       },
       preset: 'ts-jest',
       testEnvironment: 'node',

--- a/packages/log-parser/src/index.ts
+++ b/packages/log-parser/src/index.ts
@@ -1,0 +1,9 @@
+export * from './parser';
+export { readFileContent } from './parser';
+export * from './types';
+export * from './ILogParser';
+export { DefaultStrategy } from './strategies/default-strategy';
+export { BaseStrategy } from './strategies/base-strategy';
+export { JsonStrategy } from './strategies/json-strategy';
+export { JunitStrategy } from './strategies/junit-strategy';
+export { XmlStrategy } from './strategies/xml-strategy';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,7 @@
     /* === Monorepo paths ======================== */
     "baseUrl": ".",
     "paths": {
+      "@/*": ["./src/*"],
       "@testlog-inspector/*": ["packages/*/src"]
     }
   },


### PR DESCRIPTION
## Contexte et objectif
Ajout d'alias globaux `@/` et `@testlog-inspector/...` dans `tsconfig.base.json` afin de simplifier les imports entre packages. Chaque package continue d'étendre ce fichier et la configuration Jest est ajustée en conséquence. Un `index.ts` a été ajouté au parser pour exposer l'API depuis `src`.

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`

## Impact sur les autres modules
Aucun impact fonctionnel ; mise à jour de la résolution des modules et de la documentation.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880b5bf46b88321ab163818f52e7319