### PR TITLE
[web] ajout hook usePdfGenerator

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -65,6 +65,7 @@ Types autorisés : `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
 | `FileValidator`         | Vérifie l'extension et la taille                                   | `apps/api/src/log-analysis/file-validator.service.ts`  | `Express.Multer.File`  | `void` ou erreur      |
 | `LoggerInterceptor`     | Journalisation globale des requêtes                                | `apps/api/src/common/logger.interceptor.ts`            | `Request/Response`     | `Observable`          |
 | `JsPdfGenerator`        | Génère et télécharge un rapport PDF                                | `apps/web/src/lib/JsPdfGenerator.ts`                   | `ParsedLog`            | Fichier téléchargé    |
+| `usePdfGenerator`       | Renvoie la fonction `generatePdf`                 | `apps/web/src/hooks/usePdfGenerator.ts`               | `ParsedLog`            | Appelle `IPdfGenerator.generate` |
 | `SortableTable`         | Tableau générique triable et filtrable                             | `packages/ui-components/src/SortableTable.tsx`         | `data`, `columns`      | Composant React       |
 
 ## 6. Détails par agent
@@ -141,6 +142,14 @@ Types autorisés : `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
 - **Sorties** : fichier PDF téléchargé.
 - **Dépendances** : `jsPDF`, `jspdf-autotable`.
 - **Tests** : `apps/web/src/__tests__/PdfButton.test.tsx` via injection.
+
+### `usePdfGenerator`
+
+- **Rôle** : expose la fonction `generatePdf` utilisant l'implémentation courante.
+- **Entrées** : `ParsedLog`, nom de fichier optionnel.
+- **Sorties** : fichier PDF téléchargé.
+- **Dépendances** : `PdfGeneratorContext`.
+- **Tests** : `apps/web/src/__tests__/usePdfGenerator.test.tsx`.
 
 ### `SortableTable`
 

--- a/apps/web/src/__tests__/PdfButton.test.tsx
+++ b/apps/web/src/__tests__/PdfButton.test.tsx
@@ -30,7 +30,7 @@ describe("<PdfButton />", () => {
     );
     const user = userEvent.setup();
     await user.click(screen.getByRole("button"));
-    expect(generateMock).toHaveBeenCalledWith(sample);
+    expect(generateMock).toHaveBeenCalledWith(sample, undefined);
   });
 
   it("disables the button while generating", async () => {

--- a/apps/web/src/__tests__/usePdfGenerator.test.tsx
+++ b/apps/web/src/__tests__/usePdfGenerator.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { PdfGeneratorProvider } from '@/lib/PdfGeneratorContext';
+import { usePdfGenerator } from '@/hooks/usePdfGenerator';
+import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
+
+describe('usePdfGenerator', () => {
+  it('uses the injected generator', async () => {
+    const generate = vi.fn().mockResolvedValue(undefined);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PdfGeneratorProvider value={{ generate }}>
+        {children}
+      </PdfGeneratorProvider>
+    );
+    const { result } = renderHook(() => usePdfGenerator(), { wrapper });
+    await act(async () => {
+      await result.current(parsedLogFixture);
+    });
+    expect(generate).toHaveBeenCalledWith(parsedLogFixture, undefined);
+  });
+});

--- a/apps/web/src/components/PdfButton.tsx
+++ b/apps/web/src/components/PdfButton.tsx
@@ -2,7 +2,7 @@
 
 import { ParsedLog } from "@testlog-inspector/log-parser";
 import { Button } from "@testlog-inspector/ui-components";
-import { usePdfGenerator } from "@/lib/PdfGeneratorContext";
+import { usePdfGenerator } from "@/hooks/usePdfGenerator";
 
 interface Props {
   data: ParsedLog;
@@ -13,12 +13,12 @@ interface Props {
  * L'implémentation concrète peut être remplacée en tests.
  */
 export default function PdfButton({ data }: Props) {
-  const pdf = usePdfGenerator();
+  const generatePdf = usePdfGenerator();
 
   const onClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     const btn = e.currentTarget;
     btn.disabled = true;
-    await pdf.generate(data);
+    await generatePdf(data);
     btn.disabled = false;
   };
 

--- a/apps/web/src/hooks/usePdfGenerator.ts
+++ b/apps/web/src/hooks/usePdfGenerator.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { ParsedLog } from '@testlog-inspector/log-parser';
+import { usePdfGeneratorContext } from '@/lib/PdfGeneratorContext';
+
+/**
+ * Hook renvoyant la fonction de génération de PDF.
+ * Permet de remplacer l'implémentation via `PdfGeneratorProvider`.
+ */
+export function usePdfGenerator() {
+  const generator = usePdfGeneratorContext();
+  return useCallback(
+    (data: ParsedLog, filename?: string) => generator.generate(data, filename),
+    [generator],
+  );
+}

--- a/apps/web/src/lib/PdfGeneratorContext.tsx
+++ b/apps/web/src/lib/PdfGeneratorContext.tsx
@@ -11,6 +11,6 @@ export const PdfGeneratorContext = createContext<IPdfGenerator>(new JsPdfGenerat
 
 export const PdfGeneratorProvider = PdfGeneratorContext.Provider;
 
-export function usePdfGenerator() {
+export function usePdfGeneratorContext() {
   return useContext(PdfGeneratorContext);
 }


### PR DESCRIPTION
## Contexte et objectif
Ajout d’un hook `usePdfGenerator` retournant la fonction `generatePdf`. `PdfButton` l’utilise désormais pour déclencher la génération. Le `PdfGeneratorProvider` permet toujours d’injecter un générateur alternatif pour les tests.

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`
3. `pnpm format --check`

## Impact sur les autres modules
Aucun impact sur l’API, uniquement la partie web.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880d6e864d883218cf2cfddd9736ab5