### PR TITLE
[parser] introduce FileReader service

### DIFF
--- a/apps/api/src/log-analysis.module.ts
+++ b/apps/api/src/log-analysis.module.ts
@@ -10,6 +10,8 @@ import {
   LogParser,
   JsonStrategy,
   JunitStrategy,
+  FileReader,
+  IFileReader,
 } from '@testlog-inspector/log-parser';
 
 /**
@@ -25,14 +27,21 @@ import {
   controllers: [LogAnalysisController, UploadController],
   providers: [
     { provide: 'ILogAnalysisService', useClass: LogAnalysisService },
+    { provide: 'IFileReader', useClass: FileReader },
     {
       provide: 'ILogParser',
-      useFactory: () =>
-        new LogParser([new JsonStrategy(), new JunitStrategy()]),
+      useFactory: (reader: IFileReader) =>
+        new LogParser([new JsonStrategy(), new JunitStrategy()], reader),
+      inject: ['IFileReader'],
     },
     FileValidator,
     FileValidationService,
   ],
-  exports: ['ILogAnalysisService', FileValidator, FileValidationService],
+  exports: [
+    'ILogAnalysisService',
+    FileValidator,
+    FileValidationService,
+    'IFileReader',
+  ],
 })
 export class LogAnalysisModule {}

--- a/packages/log-parser/index.ts
+++ b/packages/log-parser/index.ts
@@ -15,6 +15,8 @@
 
 export * from './src/parser.js';
 export { readFileContent } from './src/parser.js';
+export { FileReader } from './src/file-reader.js';
+export type { IFileReader } from './src/file-reader.js';
 export * from './src/types.js';
 export * from './src/ILogParser.js';
 

--- a/packages/log-parser/src/file-reader.ts
+++ b/packages/log-parser/src/file-reader.ts
@@ -1,0 +1,16 @@
+export interface IFileReader {
+  read(path: string): Promise<string>;
+}
+
+export class FileReader implements IFileReader {
+  async read(path: string): Promise<string> {
+    const fs = await import('node:fs/promises');
+    try {
+      return await fs.readFile(path, 'utf-8');
+    } catch (e) {
+      throw new Error(
+        `Unable to read file "${path}" — ${(e as Error).message}`,
+      );
+    }
+  }
+}

--- a/packages/log-parser/src/index.ts
+++ b/packages/log-parser/src/index.ts
@@ -1,5 +1,7 @@
 export * from './parser';
 export { readFileContent } from './parser';
+export { FileReader } from './file-reader';
+export type { IFileReader } from './file-reader';
 export * from './types';
 export * from './ILogParser';
 export { DefaultStrategy } from './strategies/default-strategy';

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,18 +1,21 @@
-import { LogParser, readFileContent } from "@testlog-inspector/log-parser";
-import { writeFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { tempDir } from "./helpers/tempDir";
-import { vi } from "vitest";
+import {
+  LogParser,
+  readFileContent,
+  FileReader,
+} from '@testlog-inspector/log-parser';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tempDir } from './helpers/tempDir';
+import { vi } from 'vitest';
 
-describe("LogParser", () => {
+describe('LogParser', () => {
   let tmp: string;
   let cleanup: () => void;
   let dir: string;
 
   beforeEach(() => {
-    ({ dir, cleanup } = tempDir("parser-"));
-    tmp = join(dir, "test.log");
+    ({ dir, cleanup } = tempDir('parser-'));
+    tmp = join(dir, 'test.log');
   });
 
   afterEach(() => {
@@ -20,40 +23,40 @@ describe("LogParser", () => {
     cleanup();
   });
 
-  it("readFileContent returns file content", async () => {
-    writeFileSync(tmp, "abc");
+  it('readFileContent returns file content', async () => {
+    writeFileSync(tmp, 'abc');
     const res = await readFileContent(tmp);
-    expect(res).toContain("abc");
+    expect(res).toContain('abc');
   });
 
-  it("should parse a nominal log file using a single read", async () => {
-    const content = [
-      "Scenario: login_flow",
-      "ERROR: boom",
-    ].join("\n");
+  it('should parse a nominal log file using a single read', async () => {
+    const content = ['Scenario: login_flow', 'ERROR: boom'].join('\n');
     writeFileSync(tmp, content);
 
-    const parser = new LogParser([]);
-    const spy = vi.spyOn({ readFile }, "readFile");
+    const reader = new FileReader();
+    const parser = new LogParser([], reader);
+    const spy = vi.spyOn(reader, 'read');
     const res = await parser.parseFile(tmp);
     expect(spy).toHaveBeenCalledTimes(1);
 
-    expect(res.context.scenario).toBe("login_flow");
+    expect(res.context.scenario).toBe('login_flow');
     expect(res.errors).toHaveLength(1);
   });
 
-  it("should throw when file is corrupted", async () => {
+  it('should throw when file is corrupted', async () => {
     const parser = new LogParser([]);
-    await expect(parser.parseFile("nonexistent.log")).rejects.toThrow(
-      /Unable to read file/
+    await expect(parser.parseFile('nonexistent.log')).rejects.toThrow(
+      /Unable to read file/,
     );
   });
 
-  it("should propagate read errors", async () => {
-    const parser = new LogParser([]);
-    const error = new Error("permission denied");
-    vi.spyOn({ readFile }, "readFile").mockRejectedValueOnce(error);
+  it('should propagate read errors', async () => {
+    const error = new Error('permission denied');
+    const reader = {
+      read: vi.fn().mockRejectedValueOnce(error),
+    } as unknown as FileReader;
+    const parser = new LogParser([], reader);
 
-    await expect(parser.parseFile(tmp)).rejects.toThrow("permission denied");
+    await expect(parser.parseFile(tmp)).rejects.toThrow('permission denied');
   });
 });


### PR DESCRIPTION
## Contexte et objectif
- Ajout d'un service `FileReader` pour encapsuler la lecture de fichiers
- Injection de ce service dans `LogParser` et dans le module API
- Mise à jour des tests pour faciliter le mock

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
- `LogAnalysisModule` déclare maintenant `IFileReader`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880dbd07af483218143506810bb9444