### PR TITLE
[parser] refactor default strategy

### DIFF
--- a/packages/log-parser/src/parser.ts
+++ b/packages/log-parser/src/parser.ts
@@ -27,7 +27,7 @@ export class LogParser {
     private readonly reader: IFileReader = new FileReader(),
   ) {
     // Always register default fallback
-    this.registerStrategy(new DefaultStrategy());
+    this.registerStrategy(DefaultStrategy);
     // Register provided strategies (highest priority first)
     for (const s of [...strategies].reverse()) {
       this.registerStrategy(s);


### PR DESCRIPTION
## Contexte et objectif
Convertir `DefaultStrategy` en objet stateless conforme à `IParsingStrategy`.
`LogParser` enregistre maintenant directement cet objet.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
Aucun, le reste du code importe toujours `DefaultStrategy` du package `log-parser`.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880e711228883219d0326a779a6fb83