### PR TITLE
[web] Modular PDF sections

### DIFF
--- a/apps/web/src/lib/JsPdfGenerator.ts
+++ b/apps/web/src/lib/JsPdfGenerator.ts
@@ -1,104 +1,27 @@
 import { jsPDF } from 'jspdf';
-import autoTable from 'jspdf-autotable';
 import type { ParsedLog } from '@testlog-inspector/log-parser';
 import type { IPdfGenerator } from './IPdfGenerator';
-import { PDF_CONFIG, setHeading, setParagraph } from './pdf';
+import { PDF_CONFIG } from './pdf';
+import { Section, SectionState, defaultSections } from './pdf-sections';
 
 /**
  * Implémentation concrète de `IPdfGenerator` basée sur jsPDF.
  * Gère la mise en page du rapport et déclenche le téléchargement.
  */
 export class JsPdfGenerator implements IPdfGenerator {
-  async generate(data: ParsedLog, filename = 'testlog-report.pdf'): Promise<void> {
+  constructor(private readonly sections: Section[] = defaultSections) {}
+
+  async generate(
+    data: ParsedLog,
+    filename = 'testlog-report.pdf',
+  ): Promise<void> {
     const doc = new jsPDF({ unit: 'pt', format: 'a4' });
-    const { margin, lineHeight, headingSpacing } = PDF_CONFIG;
-    let cursorY = margin;
+    const state: SectionState = { cursorY: PDF_CONFIG.margin };
 
-    const addHeading = (text: string) => {
-      setHeading(doc);
-      doc.text(text, margin, cursorY);
-      cursorY += lineHeight + headingSpacing;
-    };
-
-    const addParagraph = (text: string) => {
-      setParagraph(doc);
-      const splitted = doc.splitTextToSize(
-        text,
-        doc.internal.pageSize.getWidth() - margin * 2,
-      );
-      doc.text(splitted, margin, cursorY);
-      cursorY += splitted.length * lineHeight + lineHeight;
-    };
-
-    /* ---------- Page 1 : résumé + contexte ---------- */
-    const sections = [
-      {
-        title: 'Résumé exécutif',
-        paragraphs: [data.summary.text],
-      },
-      {
-        title: 'Contexte',
-        paragraphs: Object.entries(data.context)
-          .filter(([, v]) => v)
-          .map(([k, v]) => `${k}: ${v}`),
-      },
-    ];
-
-    sections.forEach(({ title, paragraphs }) => {
-      addHeading(title);
-      paragraphs.forEach(addParagraph);
-    });
-
-    doc.addPage();
-    cursorY = margin;
-
-    /* ---------- Erreurs / exceptions ---------------- */
-    addHeading(`Erreurs / Exceptions (${data.errors.length})`);
-
-    autoTable(doc, {
-      startY: cursorY,
-      head: [['Type', 'Message', 'Ligne']],
-      body: data.errors.map((e) => [e.type, e.message, e.lineNumber.toString()]),
-      theme: 'grid',
-      styles: { fontSize: 9 },
-      headStyles: { fillColor: [22, 119, 255] },
-      margin: { left: margin, right: margin },
-      didDrawPage: (hook) => {
-        cursorY = hook.cursor.y + lineHeight;
-      },
-    });
-
-    /* ---------- Infos diverses ---------------------- */
-    const miscParts: string[] = [];
-
-    if (Object.keys(data.misc.versions).length) {
-      miscParts.push(
-        'Versions: ' +
-          Object.entries(data.misc.versions)
-            .map(([n, v]) => `${n} ${v}`)
-            .join(', '),
-      );
+    for (const section of this.sections) {
+      section(doc, data, state);
     }
 
-    if (data.misc.apiEndpoints.length) {
-      miscParts.push(`Endpoints API: ${data.misc.apiEndpoints.join(', ')}`);
-    }
-
-    if (data.misc.testCases.length) {
-      miscParts.push(`Test cases: ${data.misc.testCases.join(', ')}`);
-    }
-
-    if (data.misc.folderIds.length) {
-      miscParts.push(`Folder IDs: ${data.misc.folderIds.join(', ')}`);
-    }
-
-    if (miscParts.length) {
-      cursorY += lineHeight;
-      addHeading('Informations diverses');
-      miscParts.forEach(addParagraph);
-    }
-
-    /* ---------- Téléchargement ----------------------- */
     doc.save(filename);
   }
 }

--- a/apps/web/src/lib/pdf-sections.ts
+++ b/apps/web/src/lib/pdf-sections.ts
@@ -1,0 +1,100 @@
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import type { ParsedLog } from '@testlog-inspector/log-parser';
+import { PDF_CONFIG, setHeading, setParagraph } from './pdf';
+
+export interface SectionState {
+  cursorY: number;
+}
+
+export type Section = (
+  doc: jsPDF,
+  data: ParsedLog,
+  state: SectionState,
+) => void;
+
+function addHeading(doc: jsPDF, text: string, state: SectionState) {
+  const { margin, lineHeight, headingSpacing } = PDF_CONFIG;
+  setHeading(doc);
+  doc.text(text, margin, state.cursorY);
+  state.cursorY += lineHeight + headingSpacing;
+}
+
+function addParagraph(doc: jsPDF, text: string, state: SectionState) {
+  const { margin, lineHeight } = PDF_CONFIG;
+  setParagraph(doc);
+  const splitted = doc.splitTextToSize(
+    text,
+    doc.internal.pageSize.getWidth() - margin * 2,
+  );
+  doc.text(splitted, margin, state.cursorY);
+  state.cursorY += splitted.length * lineHeight + lineHeight;
+}
+
+export const addSummary: Section = (doc, data, state) => {
+  addHeading(doc, 'Résumé exécutif', state);
+  addParagraph(doc, data.summary.text, state);
+};
+
+export const addContext: Section = (doc, data, state) => {
+  addHeading(doc, 'Contexte', state);
+  Object.entries(data.context)
+    .filter(([, v]) => v)
+    .forEach(([k, v]) => addParagraph(doc, `${k}: ${v}`, state));
+};
+
+export const addErrors: Section = (doc, data, state) => {
+  doc.addPage();
+  state.cursorY = PDF_CONFIG.margin;
+  addHeading(doc, `Erreurs / Exceptions (${data.errors.length})`, state);
+  autoTable(doc, {
+    startY: state.cursorY,
+    head: [['Type', 'Message', 'Ligne']],
+    body: data.errors.map((e) => [e.type, e.message, e.lineNumber.toString()]),
+    theme: 'grid',
+    styles: { fontSize: 9 },
+    headStyles: { fillColor: [22, 119, 255] },
+    margin: { left: PDF_CONFIG.margin, right: PDF_CONFIG.margin },
+    didDrawPage: (hook) => {
+      state.cursorY = hook.cursor.y + PDF_CONFIG.lineHeight;
+    },
+  });
+};
+
+export const addMisc: Section = (doc, data, state) => {
+  const parts: string[] = [];
+
+  if (Object.keys(data.misc.versions).length) {
+    parts.push(
+      'Versions: ' +
+        Object.entries(data.misc.versions)
+          .map(([n, v]) => `${n} ${v}`)
+          .join(', '),
+    );
+  }
+
+  if (data.misc.apiEndpoints.length) {
+    parts.push(`Endpoints API: ${data.misc.apiEndpoints.join(', ')}`);
+  }
+
+  if (data.misc.testCases.length) {
+    parts.push(`Test cases: ${data.misc.testCases.join(', ')}`);
+  }
+
+  if (data.misc.folderIds.length) {
+    parts.push(`Folder IDs: ${data.misc.folderIds.join(', ')}`);
+  }
+
+  if (parts.length) {
+    state.cursorY += PDF_CONFIG.lineHeight;
+    addHeading(doc, 'Informations diverses', state);
+    parts.forEach((p) => addParagraph(doc, p, state));
+  }
+};
+
+export const defaultSections: Section[] = [
+  addSummary,
+  addContext,
+  addErrors,
+  addMisc,
+];


### PR DESCRIPTION
## Contexte et objectif
Refactorisation du générateur PDF pour exposer des fonctions de section dans `pdf-sections.ts` et composer `JsPdfGenerator` avec une liste modifiable.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`
3. Générer un PDF depuis l'interface web

## Impact sur les autres modules
Aucun, l'API d'utilisation reste identique.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880ec508d8883218e94df7c4bcefe5a