### PR TITLE
[web] centralize API URL in config

### DIFF
--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,0 +1,17 @@
+export interface WebConfig {
+  /** Base URL for the API used by the frontend */
+  apiUrl: string;
+}
+
+/**
+ * Reads environment variables and returns normalized configuration
+ * for the frontend. Defaults mirror the values documented in ENVIRONMENT.md.
+ */
+export function getConfig(env: NodeJS.ProcessEnv = process.env): WebConfig {
+  const apiUrl =
+    env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '') ?? 'http://localhost:3001';
+  return { apiUrl };
+}
+
+// Default configuration used by the app
+export const CONFIG = getConfig();

--- a/apps/web/src/hooks/useUpload.ts
+++ b/apps/web/src/hooks/useUpload.ts
@@ -3,10 +3,9 @@
 import { ParsedLog } from '@testlog-inspector/log-parser';
 import { useApiPost } from './useApiPost';
 import { useFileInput } from './useFileInput';
+import { CONFIG } from '../config';
 
-const API_BASE =
-  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '') ??
-  'http://localhost:3001';
+const API_BASE = CONFIG.apiUrl;
 
 /**
  * Orchestration de `useFileInput` et `useApiPost` pour analyser des fichiers log.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { ParsedLog } from '@testlog-inspector/log-parser';
+import { CONFIG } from '../config';
 
-const API_BASE =
-  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '') ?? 'http://localhost:3001';
+const API_BASE = CONFIG.apiUrl;
 
 /**
  * Analyse un ou plusieurs fichiers .log/.txt via l’API NestJS.


### PR DESCRIPTION
## Contexte et objectif
- éviter les accès directs à `process.env` dans les hooks
- partager l'URL de l'API via un module de configuration

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
- `useUpload` et `lib/api` utilisent désormais `CONFIG`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880f4e4b0b88321ab4787d62eca5506