### PR TITLE
[web] améliore lisibilité tableaux

### DIFF
--- a/apps/web/src/components/ContextTable.tsx
+++ b/apps/web/src/components/ContextTable.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from '@testlog-inspector/ui-components';
 import { TestContext } from '@testlog-inspector/log-parser';
+import { useMemo } from 'react';
 
 interface Props {
   context: TestContext;
@@ -16,7 +17,10 @@ interface Props {
  * ✔️ Pas de logique d’état : pur composant d’affichage (SRP).
  */
 export default function ContextTable({ context }: Props) {
-  const entries = Object.entries(context).filter(([, v]) => v);
+  const entries = useMemo(
+    () => Object.entries(context).filter(([, v]) => v),
+    [context],
+  );
 
   if (!entries.length) return null;
 

--- a/apps/web/src/components/ErrorTable.tsx
+++ b/apps/web/src/components/ErrorTable.tsx
@@ -20,6 +20,10 @@ interface Props {
 export default function ErrorTable({ errors }: Props) {
   const [expanded, setExpanded] = React.useState<string | null>(null);
 
+  const selectedError = React.useMemo(() => {
+    return expanded !== null ? errors[Number(expanded)] : undefined;
+  }, [expanded, errors]);
+
   const columns = React.useMemo<ColumnDef<LogError>[]>(
     () => [
       {
@@ -67,9 +71,9 @@ export default function ErrorTable({ errors }: Props) {
       initialSort={{ key: 'lineNumber', desc: false }}
       filterKeys={['type', 'message']}
     >
-      {expanded !== null && errors[Number(expanded)]?.stack && (
+      {selectedError?.stack && (
         <pre className="mt-4 max-h-64 overflow-auto rounded bg-muted p-4 text-sm">
-          {errors[Number(expanded)].stack}
+          {selectedError.stack}
         </pre>
       )}
     </TableContainer>

--- a/apps/web/src/components/MiscInfo.tsx
+++ b/apps/web/src/components/MiscInfo.tsx
@@ -17,6 +17,7 @@ interface Props {
  */
 export default function MiscInfo({ misc }: Props) {
   const { versions, apiEndpoints, testCases, folderIds } = misc;
+  const versionEntries = Object.entries(versions);
 
   const hasVersions = Object.keys(versions).length > 0;
   const hasEndpoints = apiEndpoints.length > 0;
@@ -33,7 +34,7 @@ export default function MiscInfo({ misc }: Props) {
         <section>
           <h3 className="font-medium mb-2">Versions</h3>
           <div className="flex flex-wrap gap-2">
-            {Object.entries(versions).map(([name, ver]) => (
+            {versionEntries.map(([name, ver]) => (
               <Badge key={name} variant="secondary">
                 {name}: {ver}
               </Badge>


### PR DESCRIPTION
## Contexte et objectif
- simplifie `ErrorTable` en stockant l'erreur sélectionnée
- filtre les entrées de `ContextTable` via `useMemo`
- évite les appels chaînés dans `MiscInfo`

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
- aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880f773111c8321906ef1b5af46b036