### PR TITLE
[api] centralize env access via ConfigService

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -3,15 +3,15 @@
 This project relies on a few environment variables for local and production setups.
 Each variable has a sensible default so the stack runs out‑of‑the‑box.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
+| Variable              | Default                 | Description                                                                                                     |
+| --------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `NEXT_PUBLIC_API_URL` | `http://localhost:3001` | Base URL for the NestJS API used by the Next.js frontend. `useUpload` builds its POST endpoint from this value. |
-| `API_PORT` | `3001` | Port on which the NestJS API listens. |
-| `CORS_ORIGIN` | `http://localhost:3000` | Allowed origin for CORS requests to the API. |
-| `MAX_UPLOAD_SIZE` | `52428800` | Maximum size in bytes for uploads and JSON bodies (50MB default). |
-| `UPLOAD_LIMIT_MB` | `50` | Alternate way to set the maximum upload size in megabytes. |
-| `CI` | *unset* | When defined, Playwright will not reuse an existing dev server. |
+| `API_PORT`            | `3001`                  | Port on which the NestJS API listens.                                                                           |
+| `CORS_ORIGIN`         | `http://localhost:3000` | Allowed origin for CORS requests to the API.                                                                    |
+| `MAX_UPLOAD_SIZE`     | `52428800`              | Maximum size in bytes for uploads and JSON bodies (50MB default).                                               |
+| `UPLOAD_LIMIT_MB`     | `50`                    | Alternate way to set the maximum upload size in megabytes.                                                      |
+| `CI`                  | _unset_                 | When defined, Playwright will not reuse an existing dev server.                                                 |
 
 These variables can be provided via `.env` files or your host environment.
-The NestJS API reads them via `getConfig()` defined in
-[apps/api/src/common/config.ts](apps/api/src/common/config.ts).
+The NestJS API reads them through `ConfigService` defined in
+[apps/api/src/common/config.service.ts](apps/api/src/common/config.service.ts).

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,7 +4,8 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 
 import { LogAnalysisModule } from './log-analysis.module';
 import { LoggerInterceptor } from './common/logger.interceptor';
-import { MAX_UPLOAD_SIZE } from './common/constants';
+import { ConfigModule } from './common/config.module';
+import { ConfigService } from './common/config.service';
 
 /**
  * Root module for the NestJS API.
@@ -14,9 +15,13 @@ import { MAX_UPLOAD_SIZE } from './common/constants';
  */
 @Module({
   imports: [
+    ConfigModule,
     /* -------- Upload / Multer global -------- */
-    MulterModule.register({
-        limits: { fileSize: MAX_UPLOAD_SIZE },
+    MulterModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        limits: { fileSize: config.maxUploadSize },
+      }),
+      inject: [ConfigService],
     }),
 
     /* -------- Domain modules -------- */

--- a/apps/api/src/common/config.module.ts
+++ b/apps/api/src/common/config.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { ConfigService } from './config.service';
+
+@Global()
+@Module({
+  providers: [ConfigService],
+  exports: [ConfigService],
+})
+export class ConfigModule {}

--- a/apps/api/src/common/config.service.ts
+++ b/apps/api/src/common/config.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { ApiConfig, getConfig } from './config';
+
+/**
+ * Injectable service exposing normalized configuration values.
+ * Reads environment variables once at instantiation.
+ */
+@Injectable()
+export class ConfigService {
+  private readonly config: ApiConfig = getConfig();
+
+  /** Port on which the Nest application listens. */
+  get port(): number {
+    return this.config.port;
+  }
+
+  /** Allowed origin for CORS requests. */
+  get corsOrigin(): string {
+    return this.config.corsOrigin;
+  }
+
+  /** Maximum upload size in bytes. */
+  get maxUploadSize(): number {
+    return this.config.maxUploadSize;
+  }
+}

--- a/apps/api/src/common/constants.ts
+++ b/apps/api/src/common/constants.ts
@@ -1,9 +1,0 @@
-// Global constants for the API
-// -----------------------------
-import { getConfig } from './config';
-
-// Max upload size in bytes (default 50MB)
-export const MAX_UPLOAD_SIZE = getConfig().maxUploadSize;
-
-// Express body-parser expects bytes when using a numeric limit
-

--- a/apps/api/src/log-analysis.module.ts
+++ b/apps/api/src/log-analysis.module.ts
@@ -6,6 +6,7 @@ import { UploadController } from './controllers/upload.controller';
 import { LogAnalysisService } from './services/log-analysis.service';
 import { FileValidator } from './services/file-validator.service';
 import { FileValidationService } from './services/file-validation.service';
+import { ConfigModule } from './common/config.module';
 import {
   createFileValidationMiddleware,
   composeValidators,
@@ -27,6 +28,7 @@ import {
   imports: [
     // Local Multer module (inherits the global 50MB limit)
     MulterModule,
+    ConfigModule,
   ],
   controllers: [LogAnalysisController, UploadController],
   providers: [

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,8 +4,7 @@ import { json, urlencoded } from 'express';
 import helmet from 'helmet';
 
 import { AppModule } from './app.module';
-import { MAX_UPLOAD_SIZE } from './common/constants';
-import { getConfig } from './common/config';
+import { ConfigService } from './common/config.service';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -16,30 +15,32 @@ async function bootstrap() {
   /* ---------- Security & middlewares ---------- */
   app.use(helmet());
 
+  const config = app.get(ConfigService);
+
   // Keep body size consistent with upload limit
-  app.use(json({ limit: MAX_UPLOAD_SIZE }));
-  app.use(urlencoded({ extended: true, limit: MAX_UPLOAD_SIZE }));
+  app.use(json({ limit: config.maxUploadSize }));
+  app.use(urlencoded({ extended: true, limit: config.maxUploadSize }));
 
   /* ---------- Global validation (class-validator) ---------- */
   app.useGlobalPipes(
     new ValidationPipe({
-      whitelist: true,            // retire props inconnues
+      whitelist: true, // retire props inconnues
       forbidNonWhitelisted: true, // renvoie 400 si prop inconnue
-      transform: true,            // transforme payloads en DTO
+      transform: true, // transforme payloads en DTO
       transformOptions: { enableImplicitConversion: true },
     }),
   );
 
-  const { port, corsOrigin } = getConfig();
-
   /* ---------- CORS (Next.js on :3000) ---------- */
   app.enableCors({
-    origin: corsOrigin,
+    origin: config.corsOrigin,
     credentials: true,
   });
 
-  await app.listen(port);
-  logger.log(`🚀  API TestLog Inspector running on http://localhost:${port}`);
+  await app.listen(config.port);
+  logger.log(
+    `🚀  API TestLog Inspector running on http://localhost:${config.port}`,
+  );
 }
 
 bootstrap().catch((err) => {

--- a/apps/api/src/services/file-validator.service.ts
+++ b/apps/api/src/services/file-validator.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { extname } from 'node:path';
 import type { Express } from 'express';
 import type { FileFilterCallback } from 'multer';
-import { MAX_UPLOAD_SIZE } from '../common/constants';
+import { ConfigService } from '../common/config.service';
 import { ALLOWED_EXT } from '../common/file.constants';
 import {
   ERR_FILE_TOO_LARGE,
@@ -11,11 +11,15 @@ import {
 
 /**
  * Service responsible for validating uploaded files.
- * Checks allowed extensions and maximum size (configured via MAX_UPLOAD_SIZE).
+ * Checks allowed extensions and maximum size from ConfigService.
  */
 @Injectable()
 export class FileValidator {
-  private readonly MAX_SIZE = MAX_UPLOAD_SIZE;
+  constructor(private readonly config: ConfigService) {}
+
+  private get MAX_SIZE() {
+    return this.config.maxUploadSize;
+  }
 
   validate(file: Express.Multer.File): void {
     const ext = extname(file.originalname).toLowerCase();
@@ -38,7 +42,7 @@ export const fileFilter = (
 ) => {
   try {
     // Use a fresh validator as fileFilter runs outside DI
-    new FileValidator().validate(file);
+    new FileValidator(new ConfigService()).validate(file);
     cb(null, true);
   } catch (err) {
     cb(err as Error);

--- a/tests/e2e-upload.spec.ts
+++ b/tests/e2e-upload.spec.ts
@@ -6,7 +6,7 @@ import { writeFileSync } from 'node:fs';
 import { tempDir } from './helpers/tempDir';
 
 import { AppModule } from '../apps/api/src/app.module';
-import { MAX_UPLOAD_SIZE } from '../apps/api/src/common/constants';
+import { ConfigService } from '../apps/api/src/common/config.service';
 import { ERR_FILE_TOO_LARGE } from '../apps/api/src/common/error-messages';
 
 describe('Upload log file (e2e)', () => {
@@ -51,14 +51,15 @@ describe('Upload log file (e2e)', () => {
   });
 
   it('POST /analyze should enforce MAX_UPLOAD_SIZE', async () => {
-    const oversized = Buffer.alloc(MAX_UPLOAD_SIZE + 1, '.');
+    const config = new ConfigService();
+    const oversized = Buffer.alloc(config.maxUploadSize + 1, '.');
 
     const res = await request(app.getHttpServer())
       .post('/analyze')
       .attach('files', oversized, 'big.log')
       .expect(400);
 
-    const mb = Math.ceil(MAX_UPLOAD_SIZE / (1024 * 1024));
+    const mb = Math.ceil(config.maxUploadSize / (1024 * 1024));
     expect(res.body.message).toBe(ERR_FILE_TOO_LARGE(mb));
   });
 });


### PR DESCRIPTION
## Contexte et objectif
- centraliser la lecture des variables d'environnement
- simplifier l'injection de la configuration API

## Étapes pour tester
- `pnpm install`
- `pnpm check`

## Impact sur les autres modules
- mise à jour des imports dans les tests e2e

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6880fe0a70c483219797a411aa6ce0ee