### PR TITLE
[tests] use helpers for API response access

### DIFF
--- a/apps/api/src/controllers/log-analysis.controller.spec.ts
+++ b/apps/api/src/controllers/log-analysis.controller.spec.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { INestApplication } from '@nestjs/common';
 import { MulterModule } from '@nestjs/platform-express';
 import { FileValidationService } from '../services/file-validation.service';
+import { getLogs } from '../../../../tests/helpers/api';
 
 import { LogAnalysisModule } from '../log-analysis.module';
 import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
@@ -45,7 +46,7 @@ describe('LogAnalysisController (e2e)', () => {
       .attach('files', Buffer.from('Scenario: login_flow'), 'sample.log')
       .expect(200);
 
-    expect(res.body).toEqual([parsedStub]);
+    expect(getLogs(res)).toEqual([parsedStub]);
     expect(mockService.analyze).toHaveBeenCalledTimes(1);
     expect(mockService.analyze).toHaveBeenCalledWith(
       expect.objectContaining({ originalname: 'sample.log' }),

--- a/apps/api/src/controllers/upload.controller.spec.ts
+++ b/apps/api/src/controllers/upload.controller.spec.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { INestApplication } from '@nestjs/common';
 import { MulterModule } from '@nestjs/platform-express';
 import { FileValidationService } from '../services/file-validation.service';
+import { getLogs } from '../../../../tests/helpers/api';
 
 import { LogAnalysisModule } from '../log-analysis.module';
 import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
@@ -45,7 +46,7 @@ describe('UploadController (e2e)', () => {
       .attach('files', Buffer.from('Scenario: login_flow'), 'sample.log')
       .expect(200);
 
-    expect(res.body).toEqual([parsedStub]);
+    expect(getLogs(res)).toEqual([parsedStub]);
     expect(mockService.analyze).toHaveBeenCalledTimes(1);
     expect(mockService.analyze).toHaveBeenCalledWith(
       expect.objectContaining({ originalname: 'sample.log' }),

--- a/tests/e2e-upload.spec.ts
+++ b/tests/e2e-upload.spec.ts
@@ -4,6 +4,12 @@ import request from 'supertest';
 import { join } from 'node:path';
 import { writeFileSync } from 'node:fs';
 import { tempDir } from './helpers/tempDir';
+import {
+  getLogs,
+  getSummary,
+  getContext,
+  getErrorMessage,
+} from './helpers/api';
 
 import { AppModule } from '../apps/api/src/app.module';
 import { ConfigService } from '../apps/api/src/common/config.service';
@@ -44,10 +50,11 @@ describe('Upload log file (e2e)', () => {
       .attach('files', logPath)
       .expect(200);
 
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body).toHaveLength(1);
-    expect(res.body[0]).toHaveProperty('summary');
-    expect(res.body[0]).toHaveProperty('context');
+    const logs = getLogs(res);
+    expect(Array.isArray(logs)).toBe(true);
+    expect(logs).toHaveLength(1);
+    expect(getSummary(res)).toBeDefined();
+    expect(getContext(res)).toBeDefined();
   });
 
   it('POST /analyze should enforce MAX_UPLOAD_SIZE', async () => {
@@ -60,6 +67,6 @@ describe('Upload log file (e2e)', () => {
       .expect(400);
 
     const mb = Math.ceil(config.maxUploadSize / (1024 * 1024));
-    expect(res.body.message).toBe(ERR_FILE_TOO_LARGE(mb));
+    expect(getErrorMessage(res)).toBe(ERR_FILE_TOO_LARGE(mb));
   });
 });

--- a/tests/helpers/api.ts
+++ b/tests/helpers/api.ts
@@ -1,0 +1,21 @@
+import type { ParsedLog } from '../../packages/log-parser/src/types';
+
+interface ApiResponse {
+  body: unknown;
+}
+
+export function getLogs(res: ApiResponse): ParsedLog[] {
+  return res.body as ParsedLog[];
+}
+
+export function getSummary(res: ApiResponse) {
+  return getLogs(res)[0]?.summary;
+}
+
+export function getContext(res: ApiResponse) {
+  return getLogs(res)[0]?.context;
+}
+
+export function getErrorMessage(res: ApiResponse) {
+  return (res.body as { message?: string }).message;
+}


### PR DESCRIPTION
## Contexte et objectif
Utilisation d'un helper commun afin de récupérer les informations pertinentes dans les réponses HTTP. Les tests Jest n'accèdent plus directement aux sous-propriétés de `res`, ce qui réduit le couplage avec la forme exacte des objets renvoyés.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
Aucun impact prévu.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688101898ddc8321901860366b1feca9