### PR TITLE
[utils] Injection options

### DIFF
--- a/apps/api/src/services/log-analysis.service.ts
+++ b/apps/api/src/services/log-analysis.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, Logger, BadRequestException, Inject } from "@nestjs/common";
-import type { Express } from "express";
-import { ParsedLog, ILogParser } from "@testlog-inspector/log-parser";
-import { FileValidationService } from "./file-validation.service";
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  Inject,
+} from '@nestjs/common';
+import type { Express } from 'express';
+import { ParsedLog, ILogParser } from '@testlog-inspector/log-parser';
+import { FileValidationService } from './file-validation.service';
 import { ILogAnalysisService } from './ILogAnalysisService';
 
 @Injectable()
@@ -13,14 +18,17 @@ export class LogAnalysisService implements ILogAnalysisService {
     private readonly validator: FileValidationService,
   ) {}
 
-  async analyze(file: Express.Multer.File): Promise<ParsedLog> {
+  async analyze(
+    file: Express.Multer.File,
+    parser: ILogParser = this.parser,
+  ): Promise<ParsedLog> {
     this.validator.validate(file);
 
     // Parse the file and convert parser errors into HTTP 400
     try {
-      return await this.parser.parseFile(file.path);
+      return await parser.parseFile(file.path);
     } catch (err) {
-      this.logger.error("Parsing failed", err as Error);
+      this.logger.error('Parsing failed', err as Error);
       throw new BadRequestException((err as Error).message);
     }
   }

--- a/apps/web/src/lib/JsPdfGenerator.ts
+++ b/apps/web/src/lib/JsPdfGenerator.ts
@@ -1,4 +1,5 @@
 import { createDoc, saveDoc } from './pdf-tools';
+import { jsPDF } from 'jspdf';
 import type { ParsedLog } from '@testlog-inspector/log-parser';
 import type { IPdfGenerator } from './IPdfGenerator';
 import { PDF_CONFIG } from './pdf';
@@ -9,13 +10,16 @@ import { Section, SectionState, defaultSections } from './pdf-sections';
  * Gère la mise en page du rapport et déclenche le téléchargement.
  */
 export class JsPdfGenerator implements IPdfGenerator {
-  constructor(private readonly sections: Section[] = defaultSections) {}
+  constructor(
+    private readonly sections: Section[] = defaultSections,
+    private readonly JsPdfClass: typeof jsPDF = jsPDF,
+  ) {}
 
   async generate(
     data: ParsedLog,
     filename = 'testlog-report.pdf',
   ): Promise<void> {
-    const doc = createDoc();
+    const doc = createDoc(this.JsPdfClass);
     const state: SectionState = { cursorY: PDF_CONFIG.margin };
 
     for (const section of this.sections) {

--- a/apps/web/src/lib/pdf-sections.ts
+++ b/apps/web/src/lib/pdf-sections.ts
@@ -1,4 +1,4 @@
-import { jsPDF } from 'jspdf';
+import type { jsPDF } from 'jspdf';
 import {
   addPage,
   addTable,

--- a/apps/web/src/lib/pdf-tools.ts
+++ b/apps/web/src/lib/pdf-tools.ts
@@ -1,8 +1,8 @@
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
-export function createDoc() {
-  return new jsPDF({ unit: 'pt', format: 'a4' });
+export function createDoc(JsPdfClass: typeof jsPDF = jsPDF) {
+  return new JsPdfClass({ unit: 'pt', format: 'a4' });
 }
 
 export function saveDoc(doc: jsPDF, filename: string) {
@@ -30,6 +30,10 @@ export function getPageWidth(doc: jsPDF) {
   return doc.internal.pageSize.getWidth();
 }
 
-export function addTable(doc: jsPDF, options: Parameters<typeof autoTable>[1]) {
-  autoTable(doc, options);
+export function addTable(
+  doc: jsPDF,
+  options: Parameters<typeof autoTable>[1],
+  autoTableImpl: typeof autoTable = autoTable,
+) {
+  autoTableImpl(doc, options);
 }

--- a/apps/web/src/lib/pdf.ts
+++ b/apps/web/src/lib/pdf.ts
@@ -16,17 +16,21 @@ export const PDF_CONFIG = {
 /**
  * Apply heading style to the current jsPDF instance.
  */
-export function setHeading<T extends FontUtils>(doc: T): T {
-  return doc
-    .setFontSize(PDF_CONFIG.headingSize)
-    .setFont(PDF_CONFIG.fontFamily, 'bold');
+export function setHeading<T extends FontUtils>(
+  doc: T,
+  config: typeof PDF_CONFIG = PDF_CONFIG,
+): T {
+  return doc.setFontSize(config.headingSize).setFont(config.fontFamily, 'bold');
 }
 
 /**
  * Apply paragraph style to the current jsPDF instance.
  */
-export function setParagraph<T extends FontUtils>(doc: T): T {
+export function setParagraph<T extends FontUtils>(
+  doc: T,
+  config: typeof PDF_CONFIG = PDF_CONFIG,
+): T {
   return doc
-    .setFontSize(PDF_CONFIG.paragraphSize)
-    .setFont(PDF_CONFIG.fontFamily, 'normal');
+    .setFontSize(config.paragraphSize)
+    .setFont(config.fontFamily, 'normal');
 }


### PR DESCRIPTION
## Contexte et objectif
- permettre le mock facile du parser et de `jsPDF`
- limiter l'accès direct aux librairies externes

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
- aucune régression observée

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6881372f6e488321b9202fe3f736eab3