### PR TITLE
[web] test network failure for useUpload

### DIFF
--- a/apps/web/src/__tests__/useUpload.network.test.ts
+++ b/apps/web/src/__tests__/useUpload.network.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Simulate fetch rejection
+function mockFetchRejection() {
+  return vi.fn().mockRejectedValue(new Error('network fail'));
+}
+
+describe('useUpload', () => {
+  it('exposes error on failed fetch and resets isUploading', async () => {
+    const fetchMock = mockFetchRejection();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { useUpload } = await import('../hooks/useUpload');
+    const { result } = renderHook(() => useUpload(() => {}));
+
+    const file = new File(['data'], 'fail.log');
+    await act(async () => {
+      result.current.upload([file]);
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('network fail'));
+    expect(result.current.isUploading).toBe(false);
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un test qui simule le rejet de `fetch` dans `useUpload` afin de vérifier la gestion d'erreur et le retour de `isUploading` à `false`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
Aucun.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68813d58c6988321b90f8873bfbacff2