### PR TITLE
[web] add test for pdf generation with many errors

### DIFF
--- a/apps/web/src/__tests__/JsPdfGenerator.large.test.ts
+++ b/apps/web/src/__tests__/JsPdfGenerator.large.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import parsedLogFixture from '../../../../tests/fixtures/parsedLog';
+
+const fakeDoc = {
+  setFontSize: vi.fn().mockReturnThis(),
+  setFont: vi.fn().mockReturnThis(),
+  text: vi.fn().mockReturnThis(),
+  addPage: vi.fn().mockReturnThis(),
+  splitTextToSize: vi.fn(() => ['']),
+  internal: { pageSize: { getWidth: () => 800 } },
+} as any;
+const saveDocMock = vi.fn();
+const createDocMock = vi.fn(() => fakeDoc);
+const addPageMock = vi.fn();
+const addTextMock = vi.fn();
+const getPageWidthMock = vi.fn(() => 800);
+const splitTextMock = vi.fn(() => ['']);
+const addTableMock = vi.fn((_, opts) => {
+  opts?.didDrawPage?.({ cursor: { y: 0 } } as any);
+});
+
+vi.mock('../lib/pdf-tools', () => ({
+  createDoc: createDocMock,
+  saveDoc: saveDocMock,
+  addPage: addPageMock,
+  addText: addTextMock,
+  getPageWidth: getPageWidthMock,
+  splitText: splitTextMock,
+  addTable: addTableMock,
+}));
+
+describe('JsPdfGenerator.generate with many errors', () => {
+  it('does not throw and saves the file', async () => {
+    const { JsPdfGenerator } = await import('../lib/JsPdfGenerator');
+
+    const errors = Array.from({ length: 200 }, (_, i) => ({
+      type: 'ERROR',
+      message: `error ${i}`,
+      lineNumber: i,
+      raw: `error ${i}`,
+    }));
+    const data = { ...parsedLogFixture, errors };
+
+    const generator = new JsPdfGenerator();
+    const filename = 'huge.pdf';
+    await expect(generator.generate(data, filename)).resolves.not.toThrow();
+
+    expect(saveDocMock).toHaveBeenCalledWith(fakeDoc, filename);
+  });
+});


### PR DESCRIPTION
## Contexte et objectif
Ajoute un test s'assurant que la génération PDF supporte un grand nombre d'erreurs sans exception.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
Aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68814457e6588321ae9b2a746a23b711