### PR TITLE
[log-parser] Add validate log script

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ npx tl-inspect path/to/file.log
 
 La sortie correspond au `ParsedLog` au format JSON.
 
+Un second script `validate-log` vérifie simplement qu’un fichier est valide.
+Il renvoie un code d’erreur non nul si le parsing échoue.
+
+```bash
+npx validate-log path/to/file.log
+```
+
 ## 🔌 Injection de dépendances
 
 ```ts

--- a/packages/log-parser/bin/validate-log.ts
+++ b/packages/log-parser/bin/validate-log.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { LogParser } from '../dist/index.js';
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error('Usage: validate-log <file.log>');
+    process.exit(1);
+  }
+
+  try {
+    const parser = new LogParser();
+    await parser.parseFile(file);
+    console.log('Log is valid');
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Contexte et objectif
- fournir un script permettant de vérifier qu'un fichier log est parsable
- documenter son fonctionnement dans le README

## Étapes pour tester
1. `pnpm ts-node packages/log-parser/bin/validate-log.ts path/to/file.log`
2. vérifier que le script renvoie un code d'erreur en cas d'échec du parsing

## Impact sur les autres modules
- aucun

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6881ddb65cec8321a2dc7168de49eb28