### PR TITLE
[api] include log-parser in rootDirs

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "rootDir": "src",
+    "rootDirs": ["src", "../../packages/log-parser/src"],
     "outDir": "dist",
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo",


### PR DESCRIPTION
## Contexte et objectif
Ajout du dossier `packages/log-parser/src` dans `rootDirs` du projet API pour permettre la compilation tout en conservant `rootDir`.

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test`
3. `pnpm format --check`

## Impact sur les autres modules
Aucun impact attendu en dehors de la compilation de l'API.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6881e945a55c832193c9bd195c6bdbd5