### PR TITLE
[chore] use built packages

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@testlog-inspector/*": ["packages/*/src"]
+      "@testlog-inspector/*": ["packages/*/dist"]
     }
   },
   "exclude": ["node_modules", "dist", "coverage"]


### PR DESCRIPTION
## Context and objective
- adjust TypeScript path mapping to point at built packages

## Steps to test
1. `pnpm install`
2. `pnpm build --filter @testlog-inspector/log-parser`
3. `pnpm dev`

## Impact
- API runs against compiled library without external file warnings

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6881f2f8f6548321a4783eda0c0fbbf5