### PR TITLE
[log-parser] typed regex matches

### DIFF
--- a/packages/log-parser/src/strategies/default-strategy.ts
+++ b/packages/log-parser/src/strategies/default-strategy.ts
@@ -6,7 +6,11 @@ import {
   MiscInfo,
   IParsingStrategy,
 } from '../types.js';
-import { execSummaryFrom, matchRegex } from './strategy-helpers.js';
+import {
+  execSummaryFrom,
+  matchRegex,
+  RegexMatchWithPos,
+} from './strategy-helpers.js';
 
 function extractSingle(r: RegExp, lines: string[]): string {
   const m = lines.find((l) => r.test(l));
@@ -44,7 +48,7 @@ export const DefaultStrategy: IParsingStrategy = {
 
     /* 3. Erreurs/Exceptions ------------------------------------- */
     const errorMatches = matchRegex(lines, /(ERROR|Exception)\s*[:-]\s*(.+)/);
-    const errors: LogError[] = errorMatches.map((m) => {
+    const errors: LogError[] = errorMatches.map((m: RegexMatchWithPos) => {
       const idx = m.index;
       return {
         type: m[1],
@@ -57,13 +61,21 @@ export const DefaultStrategy: IParsingStrategy = {
 
     /* 4. Infos diverses ----------------------------------------- */
     const versions = Object.fromEntries(
-      matchRegex(lines, /(\w+) v?(\d+\.\d+\.\d+)/).map((m) => [m[1], m[2]]),
+      matchRegex(lines, /(\w+) v?(\d+\.\d+\.\d+)/).map(
+        (m: RegexMatchWithPos) => [m[1], m[2]],
+      ),
     );
     const misc: MiscInfo = {
       versions,
-      apiEndpoints: matchRegex(lines, /(https?:\/\/[^\s]+)/).map((m) => m[1]),
-      testCases: matchRegex(lines, /TestCase:\s*(\w+)/).map((m) => m[1]),
-      folderIds: matchRegex(lines, /FolderID:\s*(\w+)/).map((m) => m[1]),
+      apiEndpoints: matchRegex(lines, /(https?:\/\/[^\s]+)/).map(
+        (m: RegexMatchWithPos) => m[1],
+      ),
+      testCases: matchRegex(lines, /TestCase:\s*(\w+)/).map(
+        (m: RegexMatchWithPos) => m[1],
+      ),
+      folderIds: matchRegex(lines, /FolderID:\s*(\w+)/).map(
+        (m: RegexMatchWithPos) => m[1],
+      ),
     };
 
     return { summary, context: ctx, errors, misc };


### PR DESCRIPTION
## Contexte et objectif
- aligner la stratégie par défaut sur les autres helpers
- typer explicitement les `map` de `matchRegex`

## Étapes pour tester
1. `pnpm lint`
2. `pnpm test` *(échoue actuellement : module introuvable pour `file-validation.middleware.js`)*

## Impact sur les autres modules
- aucun, modification interne au parseur

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688216ee411483219fc09bd99dbc765c