### PR TITLE
[docs] clarify .js imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Chaque `package.json` définit les commandes suivantes :
 - `playwright.config.ts` et `vitest.workspace.config.ts` pour les tests.
 - `.editorconfig` : indentation, fin de ligne et encodage unifiés.
 - Voir également [ENVIRONMENT.md](ENVIRONMENT.md) pour les variables.
+- Les imports locaux doivent inclure l’extension `.js` car `moduleResolution` est réglé sur `NodeNext` ([docs](https://www.typescriptlang.org/docs/handbook/esm-node.html)).
 
 ## 🧪 Tests
 

--- a/packages/log-parser/README.md
+++ b/packages/log-parser/README.md
@@ -1,0 +1,5 @@
+# @testlog-inspector/log-parser
+
+Library for parsing log files used by TestLog Inspector.
+
+Note: all local imports must end with `.js` because `moduleResolution` is set to `NodeNext`. See the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html) for details.


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une note dans le README principal et création du README pour `log-parser` afin de préciser que les imports locaux doivent inclure l'extension `.js` avec `moduleResolution: NodeNext`.

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
Documentation uniquement.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688239391fc08321bf3647e4995b2f94