### PR TITLE
[log-parser] adjust type import for NodeNext

### DIFF
--- a/packages/log-parser/src/parsed-log.schema.ts
+++ b/packages/log-parser/src/parsed-log.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ParsedLog } from './types';
+import type { ParsedLog } from './types.js';
 
 export const parsedLogSchema = z.object({
   summary: z.object({


### PR DESCRIPTION
## Contexte et objectif
- utilise l'extension `.js` lors de l'import du type `ParsedLog`
- assure la compatibilité NodeNext du fichier de schéma

## Étapes pour tester
1. `pnpm install`
2. `pnpm check`

## Impact sur les autres modules
- aucun, uniquement le package `log-parser`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68823c476b7483219dd36fa817a05c4f