### PR TITLE
[dev] ensure log-parser built before dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "tests"
   ],
   "scripts": {
-    "dev": "turbo run build --filter @testlog-inspector/log-parser && turbo run dev --parallel",
-    "dev:all": "turbo run build --filter @testlog-inspector/log-parser && turbo run dev --parallel",
+    "predev": "pnpm --filter @testlog-inspector/log-parser build",
+    "dev": "turbo run dev --parallel",
+    "predev:all": "pnpm --filter @testlog-inspector/log-parser build",
+    "dev:all": "turbo run dev --parallel",
     "build": "turbo run build",
     "start": "turbo run start --parallel",
     "start:prod": "concurrently -n api,web -c green,blue \"pnpm --filter @testlog-inspector/api start:prod\" \"pnpm --filter @testlog-inspector/web start\"",


### PR DESCRIPTION
## Contexte et objectif
- garantir que `pnpm dev` compile `log-parser` en amont pour éviter tout fichier manquant (Murphy)

## Étapes pour tester
1. `pnpm install`
2. `pnpm dev`

## Impact sur les autres modules
- aucun, scripts racine uniquement

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688243e91f1c8321bf3b7ba08fd9dc7d